### PR TITLE
feat: New akmods build process

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,14 +6,14 @@ on:
     paths-ignore:
       - '**.md'
       - '**.txt'
-push:
+  push:
     branches:
       - main
     paths-ignore:
       - '**.md'
       - '**.txt'
   schedule:
-    - cron: '19 20 * * *'  # 7:20pm everyday    
+    - cron: '20 19 * * *'  # 7:20pm everyday    
 env:
     IMAGE_NAME: config
     IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}


### PR DESCRIPTION
See my PRs in -main, -akmods, -nvidia. This change breaks -nvidia, as it tries to install ublue-os-just again.

- Build ublue-os-just in -config
- Adjust build time to be more in line with quay.io/fedora-ostree-desktops