### PR TITLE
added some systemd services, power targets, udev rules and flatpak gui notifications

### DIFF
--- a/files/etc/polkit-1/rules.d/cups-passwordless.rules
+++ b/files/etc/polkit-1/rules.d/cups-passwordless.rules
@@ -1,0 +1,6 @@
+polkit.addRule(function(action, subject) {
+    if (action.id == "org.opensuse.cupspkhelper.mechanism.all-edit" &&
+        subject.isInGroup("wheel")) {
+        return polkit.Result.YES;
+    }
+});

--- a/files/etc/polkit-1/rules.d/libvirt-manage.rules
+++ b/files/etc/polkit-1/rules.d/libvirt-manage.rules
@@ -1,0 +1,5 @@
+polkit.addRule(function(action, subject) {
+  if (action.id == "org.libvirt.unix.manage" && subject.local && subject.active && subject.isInGroup("wheel")) {
+      return polkit.Result.YES;
+  }
+});

--- a/files/etc/polkit-1/rules.d/udisks-encrypted-unlock.rules
+++ b/files/etc/polkit-1/rules.d/udisks-encrypted-unlock.rules
@@ -1,0 +1,5 @@
+polkit.addRule(function(action, subject) {
+  if (action.id == "org.freedesktop.udisks2.encrypted-unlock-system" && subject.local && subject.active && subject.isInGroup("wheel")) {
+      return polkit.Result.YES;
+  }
+});

--- a/files/etc/polkit-1/rules.d/udisks2-mount.rules
+++ b/files/etc/polkit-1/rules.d/udisks2-mount.rules
@@ -1,0 +1,5 @@
+polkit.addRule(function(action, subject) {
+  if (action.id == "org.freedesktop.udisks2.filesystem-mount-system" && subject.local && subject.active && subject.isInGroup("wheel")) {
+      return polkit.Result.YES;
+  }
+});

--- a/files/etc/udev/rules.d/99-batterystates.rules
+++ b/files/etc/udev/rules.d/99-batterystates.rules
@@ -1,0 +1,2 @@
+SUBSYSTEM=="power_supply", KERNEL=="AC", ATTR{online}=="0", RUN+="/usr/sbin/systemctl start battery.target"
+SUBSYSTEM=="power_supply", KERNEL=="AC", ATTR{online}=="1", RUN+="/usr/sbin/systemctl start ac.target"

--- a/files/usr/lib/systemd/system/ac.target
+++ b/files/usr/lib/systemd/system/ac.target
@@ -1,0 +1,4 @@
+[Unit]
+Description=On AC power
+DefaultDependencies=no
+StopWhenUnneeded=yes

--- a/files/usr/lib/systemd/system/battery-full.target
+++ b/files/usr/lib/systemd/system/battery-full.target
@@ -1,0 +1,4 @@
+[Unit]
+Description=At least 70% of battery
+DefaultDependencies=no
+StopWhenUnneeded=yes

--- a/files/usr/lib/systemd/system/battery.target
+++ b/files/usr/lib/systemd/system/battery.target
@@ -1,0 +1,4 @@
+[Unit]
+Description=On battery power
+DefaultDependencies=no
+StopWhenUnneeded=yes

--- a/files/usr/lib/systemd/system/fwupd.service
+++ b/files/usr/lib/systemd/system/fwupd.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Automatic firmware updates
+Documentation=man:fwupd
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/bin/fwupdmgr update -y && /usr/bin/notify-send -a "Updates" "Firmware updated" "Reboot your system now"
+
+[Install]
+WantedBy=multi-user.target

--- a/files/usr/lib/systemd/system/fwupd.timer
+++ b/files/usr/lib/systemd/system/fwupd.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Automatic Firmware updates
+Documentation=man:fwupd
+
+[Timer]
+OnBootSec=10m
+OnCalendar=0/6:00:00
+Persistent=true
+
+[Install]
+WantedBy=ac.target

--- a/files/usr/lib/systemd/user/flatpak-user-update.service
+++ b/files/usr/lib/systemd/user/flatpak-user-update.service
@@ -6,7 +6,7 @@ After=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/flatpak --user update -y --noninteractive
+ExecStart=output=$(/usr/bin/flatpak update --user -y) && num_apps=$(echo "$output" | grep -c "Updating app") ; num_packages=$(echo "$output" | grep -c "Updating runtime") && [ "$num_packages" -gt 0 ] && /usr/bin/notify-send -a "Updates" "Flatpaks updated" "$num_apps Apps, $num_packages Packages"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
I am unsure what the flatpak system updates are supposed to mean. Are these flatpaks for all users?

I added a nice GUI notification displaying the amount of updated Apps and packages (only if greater than zero), I added udev rules activating battery and ac targets for use. 

I added another currently unused "full battery" target, that could be used in exchange for the "ac target", to ensure that the update will succeed.

A config for this, for PC users, could be useful too.