### PR TITLE
Created just some udev rules and fitting systemd targets

### DIFF
--- a/files/etc/sysctl.d/90-overrides.conf
+++ b/files/etc/sysctl.d/90-overrides.conf
@@ -1,0 +1,1 @@
+vm.max_map_count=2147483642

--- a/files/etc/udev/rules.d/90-ac-states.rules
+++ b/files/etc/udev/rules.d/90-ac-states.rules
@@ -1,0 +1,5 @@
+# This module detects if AC is attached or not and activates systemd targets
+# The systemd targetscan then be used for things like batterysaving services
+
+SUBSYSTEM=="power_supply", KERNEL=="AC", ATTR{online}=="0", RUN+="/usr/sbin/systemctl start battery.target"
+SUBSYSTEM=="power_supply", KERNEL=="AC", ATTR{online}=="1", RUN+="/usr/sbin/systemctl start ac.target"

--- a/files/etc/udev/rules.d/90-ac-states.rules
+++ b/files/etc/udev/rules.d/90-ac-states.rules
@@ -1,5 +1,5 @@
 # This module detects if AC is attached or not and activates systemd targets
 # The systemd targetscan then be used for things like batterysaving services
 
-SUBSYSTEM=="power_supply", KERNEL=="AC", ATTR{online}=="0", RUN+="/usr/sbin/systemctl stop ac.target && /usr/sbin/systemctl start battery.target"
-SUBSYSTEM=="power_supply", KERNEL=="AC", ATTR{online}=="1", RUN+="/usr/sbin/systemctl stop battery.target && /usr/sbin/systemctl start ac.target"
+SUBSYSTEM=="power_supply", KERNEL=="AC", ATTR{online}=="0", RUN+="/usr/bin/systemctl stop ac.target && /usr/bin/systemctl start battery.target"
+SUBSYSTEM=="power_supply", KERNEL=="AC", ATTR{online}=="1", RUN+="/usr/bin/systemctl stop battery.target && /usr/bin/systemctl start ac.target"

--- a/files/etc/udev/rules.d/90-ac-states.rules
+++ b/files/etc/udev/rules.d/90-ac-states.rules
@@ -1,5 +1,5 @@
 # This module detects if AC is attached or not and activates systemd targets
 # The systemd targetscan then be used for things like batterysaving services
 
-SUBSYSTEM=="power_supply", KERNEL=="AC", ATTR{online}=="0", RUN+="/usr/sbin/systemctl start battery.target"
-SUBSYSTEM=="power_supply", KERNEL=="AC", ATTR{online}=="1", RUN+="/usr/sbin/systemctl start ac.target"
+SUBSYSTEM=="power_supply", KERNEL=="AC", ATTR{online}=="0", RUN+="/usr/sbin/systemctl stop ac.target && /usr/sbin/systemctl start battery.target"
+SUBSYSTEM=="power_supply", KERNEL=="AC", ATTR{online}=="1", RUN+="/usr/sbin/systemctl stop battery.target && /usr/sbin/systemctl start ac.target"

--- a/files/etc/udev/rules.d/90-battery-full.rules
+++ b/files/etc/udev/rules.d/90-battery-full.rules
@@ -1,0 +1,5 @@
+# This udev rule detects if the battery is full and attached to an AC
+# It activates a systemd target
+# This is useful to trigger firmware updates
+
+SUBSYSTEM=="power_supply", ATTR{status}=="Full|Charging", ATTR{capacity}==">=75", RUN+="/usr/bin/systemctl start battery-full.target"

--- a/files/etc/udev/rules.d/90-battery-low.rules
+++ b/files/etc/udev/rules.d/90-battery-low.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="power_supply", ATTR{status}=="Discharging", ATTR{capacity}=="<=15", RUN+="/usr/bin/systemctl start battery-low.target"

--- a/files/usr/lib/systemd/system/ac.target
+++ b/files/usr/lib/systemd/system/ac.target
@@ -1,0 +1,4 @@
+[Unit]
+Description=On AC power
+DefaultDependencies=no
+StopWhenUnneeded=yes

--- a/files/usr/lib/systemd/system/battery-full.target
+++ b/files/usr/lib/systemd/system/battery-full.target
@@ -1,0 +1,4 @@
+[Unit]
+Description=75% charged and attached to AC
+DefaultDependencies=no
+StopWhenUnneeded=yes

--- a/files/usr/lib/systemd/system/battery-low.target
+++ b/files/usr/lib/systemd/system/battery-low.target
@@ -1,0 +1,4 @@
+[Unit]
+Description=Battery Low (you can set the percentage in the udev rule)
+DefaultDependencies=no
+StopWhenUnneeded=yes

--- a/files/usr/lib/systemd/system/battery.target
+++ b/files/usr/lib/systemd/system/battery.target
@@ -1,0 +1,4 @@
+[Unit]
+Description=On battery power
+DefaultDependencies=no
+StopWhenUnneeded=yes


### PR DESCRIPTION
What I did: create udev rules detecting 
- battery full and charging
- general AC attached or "on battery"
- battery low

They trigger systemd targets that can in further steps be used from the user to add powersaving or -unlocking scripts, disabling CPU cores, throttling clockspeed and so on. It should run fully automatic, which is really nessecary.

If there are syntax errors please correct them ;D