### PR TITLE
refactor: pretty up update-services standard path

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -5,11 +5,11 @@ RUN dnf install --disablerepo='*' --enablerepo='fedora,updates' --setopt install
 ADD https://gitlab.com/jntesteves/game-devices-udev/-/archive/main/game-devices-udev-main.tar.gz /tmp/ublue-os/rpmbuild/SOURCES/game-devices-udev.tar.gz
 
 ADD files/etc/udev/rules.d /tmp/ublue-os-udev-rules/etc/udev/rules.d
-ADD files/usr/lib/systemd /tmp/ublue-os-update-services/usr/lib/systemd
-ADD files/etc/rpm-ostreed.conf /tmp/ublue-os-update-services/etc/rpm-ostreed.conf
+ADD files/usr/lib/systemd /tmp/ublue-os/update-services/usr/lib/systemd
+ADD files/etc/rpm-ostreed.conf /tmp/ublue-os/update-services/etc/rpm-ostreed.conf
 
 RUN tar cf /tmp/ublue-os/rpmbuild/SOURCES/ublue-os-udev-rules.tar.gz -C /tmp ublue-os-udev-rules
-RUN tar cf /tmp/ublue-os/rpmbuild/SOURCES/ublue-os-update-services.tar.gz -C /tmp ublue-os-update-services
+RUN tar cf /tmp/ublue-os/rpmbuild/SOURCES/ublue-os-update-services.tar.gz -C /tmp ublue-os/update-services
 
 ADD rpmspec/*.spec /tmp/ublue-os
 

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ A layer for adding enhancements to your image. Use these for better hardware sup
 Add this to your Containerfile to copy the rules over:
 
     COPY --from=ghcr.io/ublue-os/config:latest /files/ublue-os-udev-rules /
-    COPY --from=ghcr.io/ublue-os/config:latest /files/ublue-os-update-services /
+    COPY --from=ghcr.io/ublue-os/config:latest /files/ublue-os/update-services /
     
 Or if you prefer to install via an RPM package:
 
     COPY --from=ghcr.io/ublue-os/config:latest /rpms/ublue-os-udev-rules.noarch.rpm /
-    COPY --from=ghcr.io/ublue-os/config:latest /rpmm/ublue-os-update-services.noarch.rpm /
+    COPY --from=ghcr.io/ublue-os/config:latest /rpms/ublue-os-update-services.noarch.rpm /
     RUN rpm -ivh /ublue-os-udev-rules.noarch.rpm
     RUN rpm -ivh /ublue-os-update-services.noarch.rpm
 

--- a/rpmspec/ublue-os-update-services.spec
+++ b/rpmspec/ublue-os-update-services.spec
@@ -2,7 +2,7 @@ Name:           ublue-os-update-services
 Packager:       ublue-os
 Vendor:         ublue-os
 Version:        0.3
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Automatic updates for rpm-ostree and flatpak
 License:        MIT
 URL:            https://github.com/ublue-os/config
@@ -11,6 +11,8 @@ BuildArch:      noarch
 Supplements:    rpm-ostree flatpak
 
 Source0:        ublue-os-update-services.tar.gz
+
+%global sub_name %{lua:t=string.gsub(rpm.expand("%{NAME}"), "^ublue%-os%-", ""); print(t)}
 
 %description
 Adds systemd units and configuration files for enabling automatic updates in rpm-ostree and flatpak
@@ -22,11 +24,12 @@ Adds systemd units and configuration files for enabling automatic updates in rpm
 
 mkdir -p -m0755 %{buildroot}%{_datadir}/%{VENDOR}
 
-tar xf %{SOURCE0} -C %{buildroot}%{_datadir}/%{VENDOR}
+tar xf %{SOURCE0} -C %{buildroot}%{_datadir}/%{VENDOR} --strip-components=1
 
 # rpm-ostreed.conf cannot be installed in /etc as it'd conflict with upstream 
 # rpm-ostree package
-tar xf %{SOURCE0} -C %{buildroot} --strip-components=1 --exclude etc/rpm-ostreed.conf
+tar xf %{SOURCE0} -C %{buildroot} --strip-components=2 --exclude etc/rpm-ostreed.conf
+
 
 %post
 %systemd_post flatpak-system-update.timer
@@ -39,14 +42,14 @@ tar xf %{SOURCE0} -C %{buildroot} --strip-components=1 --exclude etc/rpm-ostreed
 
 
 %files
-%dir %attr(0755,root,root) %{_datadir}/%{VENDOR}/%{NAME}
-%attr(0644,root,root) %{_datadir}/%{VENDOR}/%{NAME}/%{_exec_prefix}/lib/systemd/system-preset/10-flatpak-system-update.preset
-%attr(0644,root,root) %{_datadir}/%{VENDOR}/%{NAME}/%{_exec_prefix}/lib/systemd/system/flatpak-system-update.service
-%attr(0644,root,root) %{_datadir}/%{VENDOR}/%{NAME}/%{_exec_prefix}/lib/systemd/system/flatpak-system-update.timer
-%attr(0644,root,root) %{_datadir}/%{VENDOR}/%{NAME}/%{_exec_prefix}/lib/systemd/user-preset/10-flatpak-user-update.preset
-%attr(0644,root,root) %{_datadir}/%{VENDOR}/%{NAME}/%{_exec_prefix}/lib/systemd/user/flatpak-user-update.service
-%attr(0644,root,root) %{_datadir}/%{VENDOR}/%{NAME}/%{_exec_prefix}/lib/systemd/user/flatpak-user-update.timer
-%attr(0644,root,root) %{_datadir}/%{VENDOR}/%{NAME}/%{_sysconfdir}/rpm-ostreed.conf
+%dir %attr(0755,root,root) %{_datadir}/%{VENDOR}/%{sub_name}
+%attr(0644,root,root) %{_datadir}/%{VENDOR}/%{sub_name}/%{_exec_prefix}/lib/systemd/system-preset/10-flatpak-system-update.preset
+%attr(0644,root,root) %{_datadir}/%{VENDOR}/%{sub_name}/%{_exec_prefix}/lib/systemd/system/flatpak-system-update.service
+%attr(0644,root,root) %{_datadir}/%{VENDOR}/%{sub_name}/%{_exec_prefix}/lib/systemd/system/flatpak-system-update.timer
+%attr(0644,root,root) %{_datadir}/%{VENDOR}/%{sub_name}/%{_exec_prefix}/lib/systemd/user-preset/10-flatpak-user-update.preset
+%attr(0644,root,root) %{_datadir}/%{VENDOR}/%{sub_name}/%{_exec_prefix}/lib/systemd/user/flatpak-user-update.service
+%attr(0644,root,root) %{_datadir}/%{VENDOR}/%{sub_name}/%{_exec_prefix}/lib/systemd/user/flatpak-user-update.timer
+%attr(0644,root,root) %{_datadir}/%{VENDOR}/%{sub_name}/%{_sysconfdir}/rpm-ostreed.conf
 %attr(0644,root,root) %{_exec_prefix}/lib/systemd/system-preset/10-flatpak-system-update.preset
 %attr(0644,root,root) %{_exec_prefix}/lib/systemd/system/flatpak-system-update.service
 %attr(0644,root,root) %{_exec_prefix}/lib/systemd/system/flatpak-system-update.timer
@@ -56,6 +59,9 @@ tar xf %{SOURCE0} -C %{buildroot} --strip-components=1 --exclude etc/rpm-ostreed
 
 
 %changelog
+* Fri May 12 2023 Benjamin Sherman <benjamin@holyarmy.org> - 0.3.2
+- Refactor directory structure
+
 * Fri Mar 03 2023 Joshua Stone <joshua.gage.stone@gmail.com> - 0.3
 - Enable timers for flatpak update services
 

--- a/rpmspec/ublue-os-update-services.spec
+++ b/rpmspec/ublue-os-update-services.spec
@@ -1,8 +1,8 @@
 Name:           ublue-os-update-services
 Packager:       ublue-os
 Vendor:         ublue-os
-Version:        0.3
-Release:        2%{?dist}
+Version:        0.4
+Release:        1%{?dist}
 Summary:        Automatic updates for rpm-ostree and flatpak
 License:        MIT
 URL:            https://github.com/ublue-os/config
@@ -59,7 +59,7 @@ tar xf %{SOURCE0} -C %{buildroot} --strip-components=2 --exclude etc/rpm-ostreed
 
 
 %changelog
-* Fri May 12 2023 Benjamin Sherman <benjamin@holyarmy.org> - 0.3.2
+* Fri May 12 2023 Benjamin Sherman <benjamin@holyarmy.org> - 0.4
 - Refactor directory structure
 
 * Fri Mar 03 2023 Joshua Stone <joshua.gage.stone@gmail.com> - 0.3


### PR DESCRIPTION
This modifies the ublue-os-update-services RPM to use the more standard paths agreed on in proposal for standardized locations.

See: https://github.com/orgs/ublue-os/discussions/149