### PR TITLE
refactor: pretty up udev-rules standard path

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -4,11 +4,11 @@ RUN dnf install --disablerepo='*' --enablerepo='fedora,updates' --setopt install
 
 ADD https://gitlab.com/jntesteves/game-devices-udev/-/archive/main/game-devices-udev-main.tar.gz /tmp/ublue-os/rpmbuild/SOURCES/game-devices-udev.tar.gz
 
-ADD files/etc/udev/rules.d /tmp/ublue-os-udev-rules/etc/udev/rules.d
+ADD files/etc/udev/rules.d /tmp/ublue-os/udev-rules/etc/udev/rules.d
 ADD files/usr/lib/systemd /tmp/ublue-os-update-services/usr/lib/systemd
 ADD files/etc/rpm-ostreed.conf /tmp/ublue-os-update-services/etc/rpm-ostreed.conf
 
-RUN tar cf /tmp/ublue-os/rpmbuild/SOURCES/ublue-os-udev-rules.tar.gz -C /tmp ublue-os-udev-rules
+RUN tar cf /tmp/ublue-os/rpmbuild/SOURCES/ublue-os-udev-rules.tar.gz -C /tmp ublue-os/udev-rules
 RUN tar cf /tmp/ublue-os/rpmbuild/SOURCES/ublue-os-update-services.tar.gz -C /tmp ublue-os-update-services
 
 ADD rpmspec/*.spec /tmp/ublue-os

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A layer for adding enhancements to your image. Use these for better hardware sup
 
 Add this to your Containerfile to copy the rules over:
 
-    COPY --from=ghcr.io/ublue-os/config:latest /files/ublue-os-udev-rules /
+    COPY --from=ghcr.io/ublue-os/config:latest /files/ublue-os/udev-rules /
     COPY --from=ghcr.io/ublue-os/config:latest /files/ublue-os-update-services /
     
 Or if you prefer to install via an RPM package:

--- a/rpmspec/ublue-os-udev-rules.spec
+++ b/rpmspec/ublue-os-udev-rules.spec
@@ -1,7 +1,7 @@
 Name:           ublue-os-udev-rules
 Packager:       ublue-os
 Vendor:         ublue-os
-Version:        0.2
+Version:        0.3
 Release:        1%{?dist}
 Summary:        Additional udev files for game controller support
 
@@ -14,26 +14,28 @@ Supplements:    systemd-udev
 Source0:        ublue-os-udev-rules.tar.gz
 Source1:        game-devices-udev.tar.gz
 
+%global sub_name %{lua:t=string.gsub(rpm.expand("%{NAME}"), "^ublue%-os%-", ""); print(t)}
+
 %description
-Adds various udev rules for improving game controller support
+Adds various udev rules for improving device support
 
 %prep
 %setup -q -c -T
 
 %install
-mkdir -p -m0755 %{buildroot}%{_datadir}/%{VENDOR}/{%{NAME},game-devices-udev}
+mkdir -p -m0755 %{buildroot}%{_datadir}/%{VENDOR}/{%{sub_name},game-devices-udev}
 
-tar xf %{SOURCE0} -C %{buildroot}%{_datadir}/%{VENDOR}
+tar xf %{SOURCE0} -C %{buildroot}%{_datadir}/%{VENDOR} --strip-components=1
 tar xzf %{SOURCE1} -C %{buildroot}%{_datadir}/%{VENDOR}/game-devices-udev --strip-components=1
 
 mkdir -p -m0755 %{buildroot}%{_exec_prefix}/lib/udev/rules.d
 
-cp %{buildroot}%{_datadir}/%{VENDOR}/{%{NAME}/etc/udev/rules.d,game-devices-udev}/*.rules %{buildroot}%{_exec_prefix}/lib/udev/rules.d
+cp %{buildroot}%{_datadir}/%{VENDOR}/{%{sub_name}/etc/udev/rules.d,game-devices-udev}/*.rules %{buildroot}%{_exec_prefix}/lib/udev/rules.d
 
 %files
-%dir %attr(0755,root,root) %{_datadir}/%{VENDOR}/%{NAME}
+%dir %attr(0755,root,root) %{_datadir}/%{VENDOR}/%{sub_name}
 %dir %attr(0755,root,root) %{_datadir}/%{VENDOR}/game-devices-udev
-%attr(0644,root,root) %{_datadir}/%{VENDOR}/%{NAME}/etc/udev/rules.d/*.rules
+%attr(0644,root,root) %{_datadir}/%{VENDOR}/%{sub_name}/etc/udev/rules.d/*.rules
 %attr(0644,root,root) %{_datadir}/%{VENDOR}/game-devices-udev/*.rules
 %attr(0644,root,root) %{_datadir}/%{VENDOR}/game-devices-udev/README.md
 %attr(0644,root,root) %{_datadir}/%{VENDOR}/game-devices-udev/LICENSE
@@ -43,6 +45,10 @@ cp %{buildroot}%{_datadir}/%{VENDOR}/{%{NAME}/etc/udev/rules.d,game-devices-udev
 
 
 %changelog
+* Fri May 12 2023 Benjamin Sherman <benjamin@holyarmy.org> - 0.3
+- Refactor directory structure
+- Adjust RPM description
+
 * Fri Mar 03 2023 Joshua Stone <joshua.gage.stone@gmail.com> - 0.2
 - Add game-devices-udev rules
 


### PR DESCRIPTION
This modifies the ublue-os-udev-rules RPM to use the more standard paths agreed on in proposal for standardized locations.

See: https://github.com/orgs/ublue-os/discussions/149

Also, tweaks the description of RPM to be more generic since it's not just game controllers any more.