### PR TITLE
chore: make `just` unstable by default

### DIFF
--- a/build/ublue-os-just/main.just
+++ b/build/ublue-os-just/main.just
@@ -1,5 +1,5 @@
 default:
-    @just --list
+    @just --unstable --list
     
 bios:
   systemctl reboot --firmware-setup

--- a/build/ublue-os-just/ublue-os-just.sh
+++ b/build/ublue-os-just/ublue-os-just.sh
@@ -1,17 +1,2 @@
-# Add uBlue's justfiles to users with home directories which lack a justfile.
-
-if [ ! -z "$HOME" ] && [ -d "$HOME" ] && [ ! -f "${HOME}/.justfile" ]; then
-  UBLUE_JUST=/usr/share/ublue-os/just
-  USER_JUSTFILE="${HOME}/.justfile"
-  touch "${USER_JUSTFILE}"
-  if [ -f ${UBLUE_JUST}/main.just ]; then
-    cat ${UBLUE_JUST}/main.just >> "${USER_JUSTFILE}"
-  fi
-  if [ -f ${UBLUE_JUST}/nvidia.just ] && [ rpm -q ublue-os-nvidia-addons ]; then
-    cat ${UBLUE_JUST}/nvidia.just >> "${USER_JUSTFILE}"
-  fi
-  if [ -f ${UBLUE_JUST}/custom.just ]; then
-    cat ${UBLUE_JUST}/custom.just >> "${USER_JUSTFILE}"
-  fi
-fi
+alias just="just --unstable"
 


### PR DESCRIPTION
This change allows us to recommend using just includes by default.
More: #48 

These changes are only tested manually by creating a test.sh file in `/etc/profile.d/` manually. I found out that it does not work in `fish` and other POSIX incompatible shells by default, those users need to create the alias manually.

_Required changes after merge: Documentation section about `just` instructing users to create their own "dummy" justfile._ DONE