### PR TITLE
Remove nomodeset from nvidia kargs

### DIFF
--- a/build/ublue-os-just/nvidia.just
+++ b/build/ublue-os-just/nvidia.just
@@ -3,7 +3,8 @@ set-kargs-nvidia:
     rpm-ostree kargs \
         --append-if-missing=rd.driver.blacklist=nouveau \
         --append-if-missing=modprobe.blacklist=nouveau \
-        --append-if-missing=nvidia-drm.modeset=1
+        --append-if-missing=nvidia-drm.modeset=1 \
+        --delete=nomodeset
 
 enroll-secure-boot-key:
     sudo mokutil --import /etc/pki/akmods/certs/akmods-nvidia.der


### PR DESCRIPTION
Setting nomodeset prevents nvidia-powerd from ever loading

See: https://github.com/ublue-os/nvidia/issues/71