### PR TITLE
feat: support new akmod signing key in just files

### DIFF
--- a/build/ublue-os-just/main.just
+++ b/build/ublue-os-just/main.just
@@ -22,6 +22,9 @@ distrobox-opensuse:
 distrobox-ubuntu:
   echo 'Creating Ubuntu distrobox ...'
   distrobox create --image quay.io/toolbx-images/ubuntu-toolbox:22.04 -n ubuntu -Y
+
+enroll-secure-boot-key:
+    sudo mokutil --import /etc/pki/akmods/certs/akmods-ublue.der
  
 update:
   rpm-ostree update

--- a/build/ublue-os-just/nvidia.just
+++ b/build/ublue-os-just/nvidia.just
@@ -6,7 +6,7 @@ set-kargs-nvidia:
         --append-if-missing=nvidia-drm.modeset=1 \
         --delete=nomodeset
 
-enroll-secure-boot-key:
+enroll-secure-boot-key-legacy-nvidia:
     sudo mokutil --import /etc/pki/akmods/certs/akmods-nvidia.der
 
 test-cuda:


### PR DESCRIPTION
This add secure boot signing key for akmods to the `main.just` and renames the legacy version of the command in `nvidia.just` to be specific for older nvidia-only key.