### PR TITLE
feat: create default justfile for users

### DIFF
--- a/build/ublue-os-just/ublue-os-just.sh
+++ b/build/ublue-os-just/ublue-os-just.sh
@@ -1,2 +1,11 @@
 alias just="just --unstable"
 
+# Add uBlue's justfiles to users with home directories which lack a justfile.
+
+if [ ! -z "$HOME" ] && [ -d "$HOME" ] && [ ! -f "${HOME}/.justfile" ]; then
+  cat > "${HOME}/.justfile" << EOF
+!include /usr/share/ublue-os/just/main.just
+!include /usr/share/ublue-os/just/nvidia.just
+!include /usr/share/ublue-os/just/custom.just
+EOF
+fi


### PR DESCRIPTION
When a user does not have a $HOME/.justfile, provide a default which uses `just includes` from our provided files as documented on the website.

https://ublue.it/guide/just/