### PR TITLE
Create udev rules for steering wheels

### DIFF
--- a/files/etc/udev/rules.d/99-fanatec-wheel-perms.rules
+++ b/files/etc/udev/rules.d/99-fanatec-wheel-perms.rules
@@ -1,0 +1,28 @@
+# Match kernel name of device, rather than ATTRS{idProduct} and ATTRS{idVendor}
+# so we can access the range file and leds directory. Set rw access to these 
+# files for everyone.
+SUBSYSTEMS=="hid", DRIVERS=="ftec_csl_elite", GOTO="fanatec_device"
+GOTO="fanatec_end"
+
+LABEL="fanatec_device"
+
+# FANATEC CSL Elite Wheel Base
+KERNELS=="0003:0EB7:0E03.????", GOTO="fanatec_setperms"
+# FANATEC CSL Elite Wheel Base PS44
+KERNELS=="0003:0EB7:0005.????", GOTO="fanatec_setperms"
+# FANATEC ClubSport Wheel Base V2
+KERNELS=="0003:0EB7:0001.????", GOTO="fanatec_setperms"
+# FANATEC ClubSport Wheel Base V2.5
+KERNELS=="0003:0EB7:0004.????", GOTO="fanatec_setperms"
+# FANATEC Podium Wheel Base DD1
+KERNELS=="0003:0EB7:0006.????", GOTO="fanatec_setperms"
+# FANATEC Podium Wheel Base DD2
+KERNELS=="0003:0EB7:0007.????", GOTO="fanatec_setperms"
+# FANATEC CSL DD
+KERNELS=="0003:0EB7:0020.????", GOTO="fanatec_setperms"
+GOTO="fanatec_end"
+
+LABEL="fanatec_setperms"
+RUN+="/bin/sh -c 'cd %S%p/../../../; chmod 666 range display leds/*/brightness'"
+
+LABEL="fanatec_end"

--- a/files/etc/udev/rules.d/99-logitech-wheel-perms.rules
+++ b/files/etc/udev/rules.d/99-logitech-wheel-perms.rules
@@ -1,0 +1,50 @@
+# Match kernel name of device, rather than ATTRS{idProduct} and ATTRS{idVendor}
+# so we can access the range file and leds directory. Set rw access to these 
+# files for everyone.
+# Avoid blanket matching all Logitech devices, as that causes issues with mice,
+# keyboards, and other non-wheel devices.
+
+# Logitech G923 Racing Wheel for PlayStation 4 and PC
+SUBSYSTEMS=="hid", KERNELS=="0003:046D:C266.????", DRIVERS=="logitech", RUN+="/bin/sh -c 'cd %S%p/../../../; chmod 666 alternate_modes combine_pedals range gain autocenter spring_level damper_level friction_level ffb_leds peak_ffb_level leds/*/brightness; chmod 777 leds/ leds/*'"
+
+# Logitech G923 Racing Wheel for Xbox One and PC
+SUBSYSTEMS=="hid", KERNELS=="0003:046D:C26E.????", DRIVERS=="logitech-hidpp-device", RUN+="/bin/sh -c 'cd %S%p/../../../; chmod 666 range leds/*/brightness; chmod 777 leds/ leds/*'"
+
+# Logitech G920 Driving Force Racing Wheel
+SUBSYSTEMS=="hid", KERNELS=="0003:046D:C262.????", DRIVERS=="logitech-hidpp-device", RUN+="/bin/sh -c 'cd %S%p/../../../; chmod 666 range'"
+
+# Logitech G29 Driving Force Racing Wheel
+SUBSYSTEMS=="hid", KERNELS=="0003:046D:C24F.????", DRIVERS=="logitech", RUN+="/bin/sh -c 'cd %S%p/../../../; chmod 666 alternate_modes combine_pedals range gain autocenter spring_level damper_level friction_level ffb_leds peak_ffb_level leds/*/brightness; chmod 777 leds/ leds/*'"
+
+# Logitech G27 Driving Force Racing Wheel
+SUBSYSTEMS=="hid", KERNELS=="0003:046D:C29B.????", DRIVERS=="logitech", RUN+="/bin/sh -c 'cd %S%p/../../../; chmod 666 alternate_modes combine_pedals range gain autocenter spring_level damper_level friction_level ffb_leds peak_ffb_level leds/*/brightness; chmod 777 leds/ leds/*'"
+
+# Logitech G25 Driving Force Racing Wheel
+SUBSYSTEMS=="hid", KERNELS=="0003:046D:C299.????", DRIVERS=="logitech", RUN+="/bin/sh -c 'cd %S%p/../../../; chmod 666 alternate_modes combine_pedals range gain autocenter spring_level damper_level friction_level ffb_leds peak_ffb_level'"
+
+# Logitech Driving Force GT Racing Wheel
+SUBSYSTEMS=="hid", KERNELS=="0003:046D:C29A.????", DRIVERS=="logitech", RUN+="/bin/sh -c 'cd %S%p/../../../; chmod 666 alternate_modes combine_pedals range gain autocenter spring_level damper_level friction_level ffb_leds peak_ffb_level'"
+
+# Logitech Driving Force Pro Racing Wheel
+SUBSYSTEMS=="hid", KERNELS=="0003:046D:C298.????", DRIVERS=="logitech", RUN+="/bin/sh -c 'cd %S%p/../../../; chmod 666 alternate_modes combine_pedals range gain autocenter spring_level damper_level friction_level ffb_leds peak_ffb_level'"
+
+# Logitech Driving Force Racing Wheel
+SUBSYSTEMS=="hid", KERNELS=="0003:046D:C294.????", DRIVERS=="logitech", RUN+="/bin/sh -c 'cd %S%p/../../../; chmod 666 combine_pedals range gain autocenter spring_level damper_level friction_level ffb_leds peak_ffb_level'"
+
+# Logitech Momo Force Racing Wheel
+SUBSYSTEMS=="hid", KERNELS=="0003:046D:C295.????", DRIVERS=="logitech", RUN+="/bin/sh -c 'cd %S%p/../../../; chmod 666 combine_pedals range gain autocenter spring_level damper_level friction_level ffb_leds peak_ffb_level'"
+
+# Logitech MOMO Racing USB
+SUBSYSTEMS=="hid", KERNELS=="0003:046D:CA03.????", DRIVERS=="logitech", RUN+="/bin/sh -c 'cd %S%p/../../../; chmod 666 combine_pedals range gain autocenter spring_level damper_level friction_level ffb_leds peak_ffb_level'"
+
+# Logitech WingMan Formula Force GP USB
+SUBSYSTEMS=="hid", KERNELS=="0003:046D:C293.????", DRIVERS=="logitech", RUN+="/bin/sh -c 'cd %S%p/../../../; chmod 666 combine_pedals range gain autocenter spring_level damper_level friction_level ffb_leds peak_ffb_level'"
+
+# Logitech Racing Wheel USB
+SUBSYSTEMS=="hid", KERNELS=="0003:046D:CA04.????", DRIVERS=="logitech", RUN+="/bin/sh -c 'cd %S%p/../../../; chmod 666 combine_pedals range'"
+
+# Logitech WingMan Formula GP
+SUBSYSTEMS=="hid", KERNELS=="0003:046D:C20E.????", DRIVERS=="logitech", RUN+="/bin/sh -c 'cd %S%p/../../../; chmod 666 combine_pedals range'"
+
+# Logitech WingMan Formula (Yellow) (USB)
+SUBSYSTEMS=="hid", KERNELS=="0003:046D:C202.????", DRIVERS=="logitech", RUN+="/bin/sh -c 'cd %S%p/../../../; chmod 666 range'"

--- a/files/etc/udev/rules.d/99-thrustmaster-wheel-perms.rules
+++ b/files/etc/udev/rules.d/99-thrustmaster-wheel-perms.rules
@@ -1,0 +1,20 @@
+# Match kernel name of device, rather than ATTRS{idProduct} and ATTRS{idVendor}
+# so we can access the range file and leds directory. Set rw access to these 
+# files for everyone.
+# Avoid blanket matching all Thrustmaster devices, as that causes issues with mice,
+# keyboards, and other non-wheel devices.
+
+# Thrustmaster T500RS Racing Wheel (USB)
+SUBSYSTEMS=="hid", KERNELS=="0003:044F:B65E.????", DRIVERS=="t500rs", RUN+="/bin/sh -c 'cd %S%p/../../../; chmod 666 range gain spring_level damper_level friction_level'"
+
+# Thrustmaster T300RS Racing Wheel (USB)
+SUBSYSTEMS=="hid", KERNELS=="0003:044F:B66E.????", DRIVERS=="tmff2", RUN+="/bin/sh -c 'cd %S%p/../../../; chmod 666 range gain spring_level damper_level friction_level alternate_modes'"
+
+# Thrustmaster Ferrari F1 Wheel Advanced T300 (USB)
+SUBSYSTEMS=="hid", KERNELS=="0003:044F:B66F.????", DRIVERS=="tmff2", RUN+="/bin/sh -c 'cd %S%p/../../../; chmod 666 range gain spring_level damper_level friction_level alternate_modes'"
+
+# Thrustmaster T248 Racing Wheel (USB)
+SUBSYSTEMS=="hid", KERNELS=="0003:044F:B696.????", DRIVERS=="tmff2", RUN+="/bin/sh -c 'cd %S%p/../../../; chmod 666 range gain spring_level damper_level friction_level'"
+
+# Thrustmaster T150 Racing Wheel (USB)
+SUBSYSTEMS=="hid", KERNELS=="0003:044F:B677.????", DRIVERS=="hid-t150", RUN+="/bin/sh -c 'cd %S%p/../../../; chmod 666 range gain autocenter'"


### PR DESCRIPTION
These rules are from [oversteer](https://github.com/berarma/oversteer/) and they set permissions to allow applications like Oversteer or PyLinuxWheel to configure Fanatec, Logitech, and Thrustmaster steering wheels.

These programs configure some attributes like rotation range and force feedback, exposed by the kernel driver through sysfs interfaces. Without these rules, Oversteer needs root permissions to configure these values.

