### PR TITLE
feat: standardize flatpak/rpm-ostree update timers

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -7,6 +7,7 @@ ADD https://codeberg.org/fabiscafe/game-devices-udev/archive/main.tar.gz /tmp/ub
 ADD files/etc/udev/rules.d /tmp/ublue-os/udev-rules/etc/udev/rules.d
 ADD files/usr/lib/systemd /tmp/ublue-os/update-services/usr/lib/systemd
 ADD files/etc/rpm-ostreed.conf /tmp/ublue-os/update-services/etc/rpm-ostreed.conf
+ADD files/etc/systemd /tmp/ublue-os/update-services/etc/systemd
 ADD files/usr/etc /tmp/ublue-os/signing/usr/etc
 
 RUN tar cf /tmp/ublue-os/rpmbuild/SOURCES/ublue-os-udev-rules.tar.gz -C /tmp ublue-os/udev-rules

--- a/files/etc/systemd/system/rpm-ostreed-automatic.timer
+++ b/files/etc/systemd/system/rpm-ostreed-automatic.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=rpm-ostree Automatic Update Trigger
+Documentation=man:rpm-ostree(1) man:rpm-ostreed.conf(5)
+ConditionPathExists=/run/ostree-booted
+
+[Timer]
+OnCalendar=*-*-* 4:00:00
+
+[Install]
+WantedBy=timers.target

--- a/files/usr/lib/systemd/system/flatpak-system-update.service
+++ b/files/usr/lib/systemd/system/flatpak-system-update.service
@@ -5,8 +5,5 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
-Type=oneshot
+Type=simple
 ExecStart=/usr/bin/flatpak --system update -y --noninteractive
-
-[Install]
-WantedBy=multi-user.target

--- a/files/usr/lib/systemd/system/flatpak-system-update.timer
+++ b/files/usr/lib/systemd/system/flatpak-system-update.timer
@@ -3,8 +3,7 @@ Description=Flatpak Automatic Update Trigger
 Documentation=man:flatpak(1)
 
 [Timer]
-OnBootSec=5m
-OnCalendar=0/6:00:00
+OnCalendar=*-*-* 4:00:00
 Persistent=true
 
 [Install]

--- a/files/usr/lib/systemd/user/flatpak-user-update.service
+++ b/files/usr/lib/systemd/user/flatpak-user-update.service
@@ -5,8 +5,5 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
-Type=oneshot
+Type=simple
 ExecStart=/usr/bin/flatpak --user update -y --noninteractive
-
-[Install]
-WantedBy=multi-user.target

--- a/files/usr/lib/systemd/user/flatpak-user-update.timer
+++ b/files/usr/lib/systemd/user/flatpak-user-update.timer
@@ -3,8 +3,7 @@ Description=Flatpak Automatic Update Trigger
 Documentation=man:flatpak(1)
 
 [Timer]
-OnBootSec=5m
-OnCalendar=0/6:00:00
+OnCalendar=*-*-* 4:00:00
 Persistent=true
 
 [Install]

--- a/rpmspec/ublue-os-update-services.spec
+++ b/rpmspec/ublue-os-update-services.spec
@@ -1,7 +1,7 @@
 Name:           ublue-os-update-services
 Packager:       ublue-os
 Vendor:         ublue-os
-Version:        0.4
+Version:        0.5
 Release:        1%{?dist}
 Summary:        Automatic updates for rpm-ostree and flatpak
 License:        MIT
@@ -51,15 +51,20 @@ tar xf %{SOURCE0} -C %{buildroot} --strip-components=2 --exclude etc/rpm-ostreed
 %attr(0644,root,root) %{_datadir}/%{VENDOR}/%{sub_name}/%{_exec_prefix}/lib/systemd/user/flatpak-user-update.service
 %attr(0644,root,root) %{_datadir}/%{VENDOR}/%{sub_name}/%{_exec_prefix}/lib/systemd/user/flatpak-user-update.timer
 %attr(0644,root,root) %{_datadir}/%{VENDOR}/%{sub_name}/%{_sysconfdir}/rpm-ostreed.conf
+%attr(0644,root,root) %{_datadir}/%{VENDOR}/%{sub_name}/%{_sysconfdir}/systemd/system/rpm-ostreed-automatic.timer
 %attr(0644,root,root) %{_exec_prefix}/lib/systemd/system-preset/10-flatpak-system-update.preset
 %attr(0644,root,root) %{_exec_prefix}/lib/systemd/system/flatpak-system-update.service
 %attr(0644,root,root) %{_exec_prefix}/lib/systemd/system/flatpak-system-update.timer
 %attr(0644,root,root) %{_exec_prefix}/lib/systemd/user-preset/10-flatpak-user-update.preset
 %attr(0644,root,root) %{_exec_prefix}/lib/systemd/user/flatpak-user-update.service
 %attr(0644,root,root) %{_exec_prefix}/lib/systemd/user/flatpak-user-update.timer
+%attr(0644,root,root) %{_sysconfdir}/systemd/system/rpm-ostreed-automatic.timer
 
 
 %changelog
+* Sat Jul 22 2023 Benjamin Sherman <benjamin@holyarmy.org> - 0.5
+- Set flatpak and rpm-ostree upgrade timers to run daily at 4am local time
+
 * Fri Jun 30 2023 gerblesh <101901964+gerblesh@users.noreply.github.com> - 0.4
 - Add BuildRequires for rpm-systemd-macros to fix enabling systemd services and uninstalling the RPM
 


### PR DESCRIPTION
This adds an override for the Fedora stock rpm-ostreed-automatic.timer and sets it and both the user and system flatpak timers to always run at 4:00AM localtime. If the host machine is suspended or powered down   during that time, the timers will execute on next boot. 

The flatpak update services have been simplified to not request install and to be simple services like rpm-ostreed-automatic.service.

Closes #26