### PR TITLE
fix: remove vestigal just command for legacy nvidia key

### DIFF
--- a/build/ublue-os-just/nvidia.just
+++ b/build/ublue-os-just/nvidia.just
@@ -6,9 +6,6 @@ set-kargs-nvidia:
         --append-if-missing=nvidia-drm.modeset=1 \
         --delete=nomodeset
 
-enroll-secure-boot-key-legacy-nvidia:
-    sudo mokutil --import /etc/pki/akmods/certs/akmods-nvidia.der
-
 test-cuda:
     podman run \
         --user 1000:1000 \


### PR DESCRIPTION
On June 17, 2023 we stopped using the legacy nvidia key for signing nvidia kmods, thus we can remove this command which make it easier to import the key, which doesn't even exist anymore and fails.