### PR TITLE
feat(just): add flatpaks to path

### DIFF
--- a/build/ublue-os-just/main.just
+++ b/build/ublue-os-just/main.just
@@ -42,4 +42,18 @@ update:
 
 fixscreenshare:
   cp /usr/share/applications/org.kde.xwaylandvideobridge.desktop $HOME/.config/autostart/
-  
+
+add-flatpaks-to-path:
+  #!/bin/sh
+  echo 'Adding Flatpaks to $PATH'
+  sudo bash -c 'cat > /etc/profile.d/flatpak-bindir.sh' <<-'EOF'
+  if [ -n "$XDG_DATA_HOME" ] && [ -d "$XDG_DATA_HOME/flatpak/exports/bin" ]; then
+    pathmunge "$XDG_DATA_HOME/flatpak/exports/bin"
+  elif [ -n "$HOME" ] && [ -d "$HOME/.local/share/flatpak/exports/bin" ]; then
+    pathmunge "$HOME/.local/share/flatpak/exports/bin"
+  fi
+  if [ -d /var/lib/flatpak/exports/bin ]; then
+    pathmunge /var/lib/flatpak/exports/bin
+  fi
+  EOF
+  echo 'Restart your Terminal for changes to take effect'


### PR DESCRIPTION
The shebang is there because it would throw a [whitespace error](https://just.systems/man/en/chapter_47.html) without it.