### PR TITLE
fix: set rpm-ostree updates as persistent

### DIFF
--- a/files/etc/systemd/system/rpm-ostreed-automatic.timer
+++ b/files/etc/systemd/system/rpm-ostreed-automatic.timer
@@ -6,5 +6,7 @@ ConditionPathExists=/run/ostree-booted
 [Timer]
 OnCalendar=*-*-* 4:00:00
 
+Persistent=true
+
 [Install]
 WantedBy=timers.target

--- a/files/etc/systemd/system/rpm-ostreed-automatic.timer
+++ b/files/etc/systemd/system/rpm-ostreed-automatic.timer
@@ -5,7 +5,6 @@ ConditionPathExists=/run/ostree-booted
 
 [Timer]
 OnCalendar=*-*-* 4:00:00
-
 Persistent=true
 
 [Install]


### PR DESCRIPTION
Resolves #87

According to #87, automated updates have not been running since the systemd service timer is not persistent.  Therefore, the machines must be running at 4am for the systemd service to be triggered.
This PR switches the service to persistent so it runs on next boot.

> Persistent=
Takes a boolean argument. If true, the time when the service unit was last triggered is stored on disk. When the timer is activated, the service unit is triggered immediately if it would have been triggered at least once during the time when the timer was inactive. Such triggering is nonetheless subject to the delay imposed by RandomizedDelaySec=. This is useful to catch up on missed runs of the service when the system was powered down. Note that this setting only has an effect on timers configured with OnCalendar=. Defaults to false.

> Use systemctl clean --what=state … on the timer unit to remove the timestamp file maintained by this option from disk. In particular, use this command before uninstalling a timer unit. See [systemctl(1)](https://www.freedesktop.org/software/systemd/man/systemctl.html#) for details.