### PR TITLE
fix: run flatpak two minutes after boot

### DIFF
--- a/files/usr/etc/systemd/system/rpm-ostreed-automatic.timer.d/override.conf
+++ b/files/usr/etc/systemd/system/rpm-ostreed-automatic.timer.d/override.conf
@@ -1,3 +1,4 @@
 [Timer]
+RandomizedDelaySec=10m
 OnCalendar=*-*-* 4:00:00
 Persistent=true

--- a/files/usr/lib/systemd/system/flatpak-system-update.timer
+++ b/files/usr/lib/systemd/system/flatpak-system-update.timer
@@ -3,6 +3,8 @@ Description=Flatpak Automatic Update Trigger
 Documentation=man:flatpak(1)
 
 [Timer]
+RandomizedDelaySec=10m
+OnBootSec=2m
 OnCalendar=*-*-* 4:00:00
 Persistent=true
 

--- a/files/usr/lib/systemd/user/flatpak-user-update.timer
+++ b/files/usr/lib/systemd/user/flatpak-user-update.timer
@@ -3,6 +3,8 @@ Description=Flatpak Automatic Update Trigger
 Documentation=man:flatpak(1)
 
 [Timer]
+RandomizedDelaySec=10m
+OnBootSec=2m
 OnCalendar=*-*-* 4:00:00
 Persistent=true
 

--- a/rpmspec/ublue-os-update-services.spec
+++ b/rpmspec/ublue-os-update-services.spec
@@ -65,11 +65,11 @@ tar xf %{SOURCE0} -C %{buildroot} --strip-components=2 --exclude etc/rpm-ostreed
 
 
 %changelog
-* Sat Aug 12 2023 Fifty Dinar <srbaizoki4@tuta.io> - 0.7
-- Switch to drop-in override for rpm-ostreed-automatic.service modifications
+* Sat Aug 12 2023 Benjamin Sherman <benjamin@holyarmy.org> - 0.7
+- Add randmized delay to update timers, and always run flatpak updates on boot
 
-* Sat Aug 12 2023 Benjamin Sherman <benjamin@holyarmy.org> - 0.6
-- Switch to drop-in override for rpm-ostreed-automatic.timer modifications
+* Sat Aug 12 2023 Fifty Dinar <srbaizoki4@tuta.io> - 0.6
+- Switch to drop-in overrides for rpm-ostreed-automatic modifications
 
 * Sat Jul 22 2023 Benjamin Sherman <benjamin@holyarmy.org> - 0.5
 - Set flatpak and rpm-ostree upgrade timers to run daily at 4am local time


### PR DESCRIPTION
This should fix #89 by ensuring that flatpak update timers always run at least two minutes after system boot.

Also, randomized delay was added for both flatpak update and rpm-ostreed-automatic timers to prevent the download and system load from always hitting at exactly the same time.