### PR TITLE
Update main.just

### DIFF
--- a/build/ublue-os-just/main.just
+++ b/build/ublue-os-just/main.just
@@ -66,3 +66,8 @@ update:
 fixscreenshare:
   cp /usr/share/applications/org.kde.xwaylandvideobridge.desktop $HOME/.config/autostart/
   
+# Add user to libvirt group after layering libvirt packages
+usermod-libvirt:
+  grep -E '^libvirt:' /usr/lib/group | sudo tee -a /etc/group
+  sudo usermod -aG libvirt $USER
+  echo 'You will need to log off and log back in to apply these changes.'


### PR DESCRIPTION
https://docs.fedoraproject.org/en-US/fedora-silverblue/troubleshooting/#_unable_to_add_user_to_group

might be easier for a new user to Silverblue if they layer libvirt packages.