### PR TITLE
Allow archive formats in container policy

### DIFF
--- a/files/usr/etc/containers/policy.json
+++ b/files/usr/etc/containers/policy.json
@@ -70,6 +70,20 @@
                 }
             ]
         },
+        "oci-archive": {
+            "": [
+                {
+                    "type": "insecureAcceptAnything"
+                }
+            ]
+        },
+        "docker-archive": {
+            "": [
+                {
+                    "type": "insecureAcceptAnything"
+                }
+            ]
+        },
         "tarball": {
             "": [
                 {


### PR DESCRIPTION
Fixes #102.

Adds `oci-archive` and `docker-archive` with `insecureAcceptAnything` to the default container policy. This allows `docker-compose` image builds using BuildKit to transfer images to Podman.
