### PR TITLE
fix(just): add i915 to modprobe.blacklist

### DIFF
--- a/build/ublue-os-just/nvidia.just
+++ b/build/ublue-os-just/nvidia.just
@@ -3,6 +3,7 @@ set-kargs-nvidia:
     rpm-ostree kargs \
         --append-if-missing=rd.driver.blacklist=nouveau \
         --append-if-missing=modprobe.blacklist=nouveau \
+        --append-if-missing=rd.driver.blacklist=i915 \
         --append-if-missing=modprobe.blacklist=i915 \
         --append-if-missing=nvidia-drm.modeset=1 \
         --delete=nomodeset

--- a/build/ublue-os-just/nvidia.just
+++ b/build/ublue-os-just/nvidia.just
@@ -3,6 +3,7 @@ set-kargs-nvidia:
     rpm-ostree kargs \
         --append-if-missing=rd.driver.blacklist=nouveau \
         --append-if-missing=modprobe.blacklist=nouveau \
+        --append-if-missing=modprobe.blacklist=i915 \
         --append-if-missing=nvidia-drm.modeset=1 \
         --delete=nomodeset
 


### PR DESCRIPTION
If you have an nvidia GPU and a CPU with igpu inside you won't be able to start your system probably due to driver/module conflicts?
One possible workaround is to set ```i915.modeset=0``` or ```module.blacklist=i915``` to your grub config as described below.

Some of the research on this is described [here](https://askubuntu.com/questions/1483916/ubuntu-with-disk-encryption-doesnt-show-me-encryption-password-dialog-at-startu/1483936#1483936) .