### PR TITLE
fix(just): use delete-if-present in set-kargs-nvidia

### DIFF
--- a/build/ublue-os-just/nvidia.just
+++ b/build/ublue-os-just/nvidia.just
@@ -4,7 +4,7 @@ set-kargs-nvidia:
         --append-if-missing=rd.driver.blacklist=nouveau \
         --append-if-missing=modprobe.blacklist=nouveau \
         --append-if-missing=nvidia-drm.modeset=1 \
-        --delete=nomodeset
+        --delete-if-present=nomodeset
 
 test-cuda:
     podman run \


### PR DESCRIPTION
Use `--delete-if-present` so it would not fail if `nomodeset` not exists