### PR TITLE
feat(just): add mullvad vpn shortcut

### DIFF
--- a/build/ublue-os-just/70-vpn.just
+++ b/build/ublue-os-just/70-vpn.just
@@ -1,0 +1,22 @@
+
+# Install Mullvad VPN
+vpn-mullvad:
+  echo 'Downloading files needed for installation ...'
+  wget -qnc --trust-server-names https://mullvad.net/download/app/rpm/latest -P /tmp
+  wget -qnc --trust-server-names https://mullvad.net/download/app/rpm/latest/signature -P /tmp
+  wget -qnc https://mullvad.net/media/mullvad-code-signing.asc -P /tmp
+  echo 'Importing Mullvad GPG key ...'
+  gpg --import /tmp/mullvad-code-signing.asc
+  echo 'Verify the Mullvad VPN app ...'
+  gpg --verify /tmp/MullvadVPN-*.rpm.asc && rpm-ostree install /tmp/MullvadVPN-*.rpm
+
+# Install Mullvad VPN Beta
+vpn-mullvad-beta:
+  echo 'Downloading files needed for installation ...'
+  wget -qnc --trust-server-names https://mullvad.net/download/app/rpm/latest-beta -P /tmp
+  wget -qnc --trust-server-names https://mullvad.net/download/app/rpm/latest-beta/signature -P /tmp
+  wget -qnc https://mullvad.net/media/mullvad-code-signing.asc -P /tmp
+  echo 'Importing Mullvad GPG key ...'
+  gpg --import /tmp/mullvad-code-signing.asc
+  echo 'Verify the Mullvad VPN Beta app ...'
+  gpg --verify /tmp/MullvadVPN-*beta*.rpm.asc && rpm-ostree install /tmp/MullvadVPN-*beta*.rpm

--- a/build/ublue-os-just/main.just
+++ b/build/ublue-os-just/main.just
@@ -69,4 +69,14 @@ update:
 # Enable xwaylandvideobridge
 fixscreenshare:
   cp /usr/share/applications/org.kde.xwaylandvideobridge.desktop $HOME/.config/autostart/
-  
+
+# Install Mullvad VPN
+vpn-mullvad:
+  echo 'Downloading files needed for installation ...'
+  wget -q --trust-server-names https://mullvad.net/download/app/rpm/latest -P /tmp
+  wget -q --trust-server-names https://mullvad.net/download/app/rpm/latest/signature -P /tmp
+  wget -q https://mullvad.net/media/mullvad-code-signing.asc -P /tmp
+  echo 'Importing Mullvad GPG key ...'
+  gpg --import /tmp/mullvad-code-signing.asc
+  echo 'Verify the Mullvad VPN app'
+  gpg --verify /tmp/MullvadVPN-*.rpm.asc && rpm-ostree install /tmp/MullvadVPN-*.rpm

--- a/build/ublue-os-just/main.just
+++ b/build/ublue-os-just/main.just
@@ -69,14 +69,3 @@ update:
 # Enable xwaylandvideobridge
 fixscreenshare:
   cp /usr/share/applications/org.kde.xwaylandvideobridge.desktop $HOME/.config/autostart/
-
-# Install Mullvad VPN
-vpn-mullvad:
-  echo 'Downloading files needed for installation ...'
-  wget -q --trust-server-names https://mullvad.net/download/app/rpm/latest -P /tmp
-  wget -q --trust-server-names https://mullvad.net/download/app/rpm/latest/signature -P /tmp
-  wget -q https://mullvad.net/media/mullvad-code-signing.asc -P /tmp
-  echo 'Importing Mullvad GPG key ...'
-  gpg --import /tmp/mullvad-code-signing.asc
-  echo 'Verify the Mullvad VPN app'
-  gpg --verify /tmp/MullvadVPN-*.rpm.asc && rpm-ostree install /tmp/MullvadVPN-*.rpm


### PR DESCRIPTION
address #105

Is it maybe better to have a separate justfile only intended for VPN install scripts? In the future when we have a couple of VPN providers this file could get very cluttered.

How should we deal with beta/arm versions of VPNs?