### PR TITLE
Fix #117 (flatpak update failing)

### DIFF
--- a/files/usr/lib/systemd/system/flatpak-system-update.service
+++ b/files/usr/lib/systemd/system/flatpak-system-update.service
@@ -5,7 +5,5 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
-Type=simple
-ExecStartPre=/usr/bin/flatpak --system uninstall --unused -y --noninteractive
-ExecStart=/usr/bin/flatpak --system update -y --noninteractive
-ExecStartPost=/usr/bin/flatpak --system repair
+Type=oneshot
+ExecStart=/usr/bin/flatpak --system uninstall --unused -y --noninteractive ; /usr/bin/flatpak --system update -y --noninteractive ; /usr/bin/flatpak --system repair

--- a/files/usr/lib/systemd/user/flatpak-user-update.service
+++ b/files/usr/lib/systemd/user/flatpak-user-update.service
@@ -5,7 +5,5 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
-Type=simple
-ExecStartPre=/usr/bin/flatpak --user uninstall --unused -y --noninteractive
-ExecStart=/usr/bin/flatpak --user update -y --noninteractive
-ExecStartPost=/usr/bin/flatpak --user repair
+Type=oneshot
+ExecStart=/usr/bin/flatpak --user uninstall --unused -y --noninteractive ; /usr/bin/flatpak --user update -y --noninteractive ; /usr/bin/flatpak --user repair


### PR DESCRIPTION
This PR fixes issue #117, by making all the commands in the ```flatpak-system-update``` service run from ```ExecStart=```, which prevents them from being automatically killed from time to time.