### PR TITLE
feat: check metered connection before automatic updates

### DIFF
--- a/build/ublue-os-just/10-update.just
+++ b/build/ublue-os-just/10-update.just
@@ -5,3 +5,13 @@ update:
   rpm-ostree update
   flatpak update -y
   distrobox upgrade -a
+
+# Disable all auto-update timers
+disable-updates:
+  sudo systemctl disable --now flatpak-system-update.timer rpm-ostreed-automatic.timer
+  sudo systemctl disable --now --user flatpak-user-update.timer
+
+# Enable all auto-update timers
+enable-updates:
+  sudo systemctl enable --now flatpak-system-update.timer rpm-ostreed-automatic.timer
+  sudo systemctl enable --now --user flatpak-user-update.timer

--- a/build/ublue-os-just/ublue-os-just.spec
+++ b/build/ublue-os-just/ublue-os-just.spec
@@ -1,7 +1,7 @@
 Name:           ublue-os-just
 Packager:       ublue-os
 Vendor:         ublue-os
-Version:        0.4
+Version:        0.6
 Release:        1%{?dist}
 Summary:        ublue-os just integration
 License:        MIT
@@ -45,6 +45,9 @@ done
 %attr(0644,root,root) %{_datadir}/%{VENDOR}/justfile
 
 %changelog
+* Mon Oct 2 2023 ArtikusHG <24320212+ArtikusHG@users.noreply.github.com> - 0.6
+- Add commands to disable and enable automatic updates to 60-updates.just
+
 * Sat Sep 23 2023 Kyle Gospodnetich <me@kylegospodneti.ch> - 0.5
 - Remove fish shell support
 

--- a/files/usr/etc/systemd/system/rpm-ostreed-automatic.service.d/override.conf
+++ b/files/usr/etc/systemd/system/rpm-ostreed-automatic.service.d/override.conf
@@ -1,3 +1,6 @@
 [Unit]
 Wants=network-online.target
 After=network-online.target
+
+[Service]
+ExecCondition=/bin/bash -c '[[ "$(busctl get-property org.freedesktop.NetworkManager /org/freedesktop/NetworkManager org.freedesktop.NetworkManager Metered | cut -c 3-)" == @(2|4) ]]'

--- a/files/usr/lib/systemd/system/flatpak-system-update.service
+++ b/files/usr/lib/systemd/system/flatpak-system-update.service
@@ -6,4 +6,5 @@ After=network-online.target
 
 [Service]
 Type=oneshot
+ExecCondition=/bin/bash -c '[[ "$(busctl get-property org.freedesktop.NetworkManager /org/freedesktop/NetworkManager org.freedesktop.NetworkManager Metered | cut -c 3-)" == @(2|4) ]]'
 ExecStart=/usr/bin/flatpak --system uninstall --unused -y --noninteractive ; /usr/bin/flatpak --system update -y --noninteractive ; /usr/bin/flatpak --system repair

--- a/files/usr/lib/systemd/user/flatpak-user-update.service
+++ b/files/usr/lib/systemd/user/flatpak-user-update.service
@@ -6,4 +6,5 @@ After=network-online.target
 
 [Service]
 Type=oneshot
+ExecCondition=/bin/bash -c '[[ "$(busctl get-property org.freedesktop.NetworkManager /org/freedesktop/NetworkManager org.freedesktop.NetworkManager Metered | cut -c 3-)" == @(2|4) ]]'
 ExecStart=/usr/bin/flatpak --user uninstall --unused -y --noninteractive ; /usr/bin/flatpak --user update -y --noninteractive ; /usr/bin/flatpak --user repair

--- a/rpmspec/ublue-os-update-services.spec
+++ b/rpmspec/ublue-os-update-services.spec
@@ -1,7 +1,7 @@
 Name:           ublue-os-update-services
 Packager:       ublue-os
 Vendor:         ublue-os
-Version:        0.7
+Version:        0.8
 Release:        1%{?dist}
 Summary:        Automatic updates for rpm-ostree and flatpak
 License:        MIT

--- a/rpmspec/ublue-os-update-services.spec
+++ b/rpmspec/ublue-os-update-services.spec
@@ -65,6 +65,9 @@ tar xf %{SOURCE0} -C %{buildroot} --strip-components=2 --exclude etc/rpm-ostreed
 
 
 %changelog
+* Mon Oct 2 2023 ArtikusHG <24320212+ArtikusHG@users.noreply.github.com> - 0.8
+- Add metered connection check to system and flatpak update services
+
 * Sat Aug 12 2023 Benjamin Sherman <benjamin@holyarmy.org> - 0.7
 - Add randmized delay to update timers, and always run flatpak updates on boot
 


### PR DESCRIPTION
This PR prevents automatic update services from running on a metered connection (see #113 for more details).

Explanation:

- ```/bin/bash -c``` is needed because systemd runs binaries, not shell scripts
- ```busctl get-property org.freedesktop.NetworkManager /org/freedesktop/NetworkManager org.freedesktop.NetworkManager Metered``` gets the value of the metered connection property
- ...but it doesn't just return the number, also some symbols behind it, so we trim them with ```| cut -c 3-```
- ```== @(2|4)``` checks if the result is either 2 (NM_METERED_NO) or 4 (NM_METERED_GUESS_NO), as per documentation:

![image](https://github.com/ublue-os/config/assets/24320212/f454e8e2-b11c-44cb-aedf-85f39dcca2bf)

- the service only runs if the above code returns a success code

Regarding DE app stores and such: GNOME software seems to already have support for not running updates on a metered connection, pretty sure KDE and others have the same thing.

Note: I did test this and it seems to work, but I would like at least a few more people to confirm this before we can get this merged.

Also includes just commands to disable/enable automatic updates at will, without marking the connection as metered.