### PR TITLE
feat(just): add kernel parameters for overclocking AMD GPUs

### DIFF
--- a/build/ublue-os-just/41-amd.just
+++ b/build/ublue-os-just/41-amd.just
@@ -1,0 +1,12 @@
+# vim: set ft=make :
+# Set needed kernel parameters for Overclocking AMD GPUs
+amd-set-oc-kargs:
+  #!/usr/bin/env bash
+  if lsmod | grep -wq "amdgpu"; then
+    rpm-ostree kargs \
+      --append-if-missing=amdgpu.ppfeaturemask=0xffffffff \
+      --delete-if-present=nomodeset \
+      --delete-if-present=vga
+  else
+    echo 'You do not appear to use a AMD GPU. The amdgpu kernel module is not loaded.'
+  fi

--- a/build/ublue-os-just/ublue-os-just.spec
+++ b/build/ublue-os-just/ublue-os-just.spec
@@ -16,9 +16,9 @@ Source2:        10-update.just
 Source3:        20-clean.just
 Source4:        30-distrobox.just
 Source5:        40-nvidia.just
-Source6:        50-akmods.just
-Source7:        60-custom.just
-
+Source6:        41-amd.just
+Source7:        50-akmods.just
+Source8:        60-custom.just
 %global sub_name %{lua:t=string.gsub(rpm.expand("%{NAME}"), "^ublue%-os%-", ""); print(t)}
 
 %description


### PR DESCRIPTION
This is a kernel parameter change [required to overclock your AMD GPU.](https://wiki.archlinux.org/title/AMDGPU#Overclocking)
This is necessary to make programs like [CoreCtrl](https://gitlab.com/corectrl/corectrl) have full functionality.