### PR TITLE
fix: add nvidia device argument to cuda test

### DIFF
--- a/build/ublue-os-just/40-nvidia.just
+++ b/build/ublue-os-just/40-nvidia.just
@@ -22,6 +22,7 @@ nvidia-test-cuda:
       --security-opt=no-new-privileges \
       --cap-drop=ALL \
       --security-opt label=type:nvidia_container_t  \
+      --device=nvidia.com/gpu=all \
       docker.io/mirrorgooglecontainers/cuda-vector-add:v0.1
   else
     echo 'The Nvidia kernel module is not loaded. You may be using secure boot without the needed signing key, lacking the needed kargs, or may not be on a Nvidia image. See "just enroll-secure-boot-key" and "just nvidia-set-kargs".'


### PR DESCRIPTION
This is required since nvidia container toolkit 1.14