### PR TITLE
feat: add ujust, add chsh just task

### DIFF
--- a/build/ublue-os-just/00-default.just
+++ b/build/ublue-os-just/00-default.just
@@ -1,5 +1,8 @@
 # vim: set ft=make :
 
+uid := `id -u`
+shell := `grep :$(id -u): /etc/passwd | cut -d: -f7`
+
 set allow-duplicate-recipes
 set ignore-comments
 

--- a/build/ublue-os-just/00-default.just
+++ b/build/ublue-os-just/00-default.just
@@ -10,6 +10,21 @@ _default:
 bios:
   systemctl reboot --firmware-setup
 
+# Change the user's shell
+chsh new_shell:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  if [ "{{shell}}" = "{{new_shell}}" ] ; then
+    printf "Your shell is already set to %s.\n" "{{new_shell}}"
+  else
+    if [ -x "{{new_shell}}" ] ; then
+      sudo usermod $USER --shell "{{new_shell}}"
+      printf "%s's shell is now %s.\n" "$USER" "{{new_shell}}"
+    else
+      echo "{{new_shell}} does not exist or is not executable!"
+    fi
+  fi
+
 # Regenerate GRUB config, useful in dual-boot scenarios where a second operating system isn't listed
 regenerate-grub:
   #!/usr/bin/env bash

--- a/build/ublue-os-just/build.sh
+++ b/build/ublue-os-just/build.sh
@@ -8,6 +8,7 @@ mkdir -p /tmp/ublue-os/rpmbuild/SOURCES
 
 cp ${SCRIPT_DIR}/*.just /tmp/ublue-os/rpmbuild/SOURCES
 cp ${SCRIPT_DIR}/ublue-os-just.sh /tmp/ublue-os/rpmbuild/SOURCES
+cp ${SCRIPT_DIR}/ujust /tmp/ublue-os/rpmbuild/SOURCES
 
 rpmbuild -ba \
     --define '_topdir /tmp/ublue-os/rpmbuild' \

--- a/build/ublue-os-just/ublue-os-just.spec
+++ b/build/ublue-os-just/ublue-os-just.spec
@@ -1,7 +1,7 @@
 Name:           ublue-os-just
 Packager:       ublue-os
 Vendor:         ublue-os
-Version:        0.6
+Version:        0.7
 Release:        1%{?dist}
 Summary:        ublue-os just integration
 License:        MIT
@@ -18,6 +18,7 @@ Source4:        30-distrobox.just
 Source5:        40-nvidia.just
 Source6:        50-akmods.just
 Source7:        60-custom.just
+Source8:        ujust
 
 %global sub_name %{lua:t=string.gsub(rpm.expand("%{NAME}"), "^ublue%-os%-", ""); print(t)}
 
@@ -38,13 +39,22 @@ for justfile in %{buildroot}%{_datadir}/%{VENDOR}/%{sub_name}/*.just; do
 	echo "!include %{_datadir}/%{VENDOR}/%{sub_name}/$(basename ${justfile})" >> "%{buildroot}%{_datadir}/%{VENDOR}/justfile"
 done
 
+# Add global "ujust" script to run just with --unstable
+mkdir -p -m0755  %{buildroot}%{_bindir}
+install -Dm755 %{SOURCE8} %{buildroot}%{_bindir}/ujust
+
 %files
 %dir %attr(0755,root,root) %{_datadir}/%{VENDOR}/%{sub_name}
 %attr(0755,root,root) %{_sysconfdir}/profile.d/ublue-os-just.sh
 %attr(0644,root,root) %{_datadir}/%{VENDOR}/%{sub_name}/*.just
 %attr(0644,root,root) %{_datadir}/%{VENDOR}/justfile
+%attr(0755,root,root) %{_bindir}/ujust
 
 %changelog
+* Fri Oct 13 2023 bri <284789+b-@users.noreply.github.com> - 0.7
+- Add ujust runner
+- Add chsh task
+
 * Mon Oct 2 2023 ArtikusHG <24320212+ArtikusHG@users.noreply.github.com> - 0.6
 - Add commands to disable and enable automatic updates to 60-updates.just
 

--- a/build/ublue-os-just/ujust
+++ b/build/ublue-os-just/ujust
@@ -1,0 +1,2 @@
+#!/bin/sh
+/usr/bin/just --unstable --justfile /usr/share/ublue-os/justfile "${@}"


### PR DESCRIPTION
This adds a little shim, `/usr/bin/ujust`, to run, `just --unstable --justfile /usr/share/ublue-os/justfile`.

I think this is a much cleaner way to run our `just` tasks than putting a `~/.justfile` in the home directory, for a number of reasons. One of them is that this does not require aliasing `just=just --unstable`, and another is that a user can actually have their own `~/.justfile` with no regard for including our global one.

I didn't remove the `just` aliases from the shell dotfiles, because I'm not sure what breaking changes that might cause -- documentation, for sure, but also does yafti or anything else depend on that?

~~Also to be honest I'm not sure where the default just alias comes from. I didn't actually look yet :P~~ _the alias comes from this repo_

I did this because I realized how much duplicate code and room for errors I had in the shell change tasks I rewrote -- I think it's much better to write a task with an argument, `just chsh /usr/bin/newshell`, and then call that from other tasks that need to change the shell. However, I saw the limitations of using shell aliases to add the `--unstable` flag quite quickly -- my sub-just-invocations became longer than I'd like them to be. See https://just.systems/man/en/chapter_40.html and note how much nicer that is than `just --unstable --file /usr/share/ublue-os/justfile`...

I'd definitely like to see others' thoughts on this! Feel free to ping me on Discord @bri9.

PR is draft because I'd like others to test it just in case I messed something up here...

@castrojo suggested this go in this repo. I've never built an RPM before and I'm not certain I did it right, so I'm sort of crossing my fingers and teaching myself how to test etc. as I go along...

--bri