### PR TITLE
feat(udev): add Sunshine udev rules (fix #119)

### DIFF
--- a/files/etc/udev/rules.d/85-sunshine.rules
+++ b/files/etc/udev/rules.d/85-sunshine.rules
@@ -1,0 +1,1 @@
+KERNEL=="uinput", SUBSYSTEM=="misc", OPTIONS+="static_node=uinput", TAG+="uaccess"

--- a/rpmspec/ublue-os-udev-rules.spec
+++ b/rpmspec/ublue-os-udev-rules.spec
@@ -1,7 +1,7 @@
 Name:           ublue-os-udev-rules
 Packager:       ublue-os
 Vendor:         ublue-os
-Version:        0.5
+Version:        0.6
 Release:        1%{?dist}
 Summary:        Additional udev files for device support
 
@@ -45,6 +45,9 @@ cp %{buildroot}%{_datadir}/%{VENDOR}/{%{sub_name}/etc/udev/rules.d,game-devices-
 
 
 %changelog
+* Fri Oct 20 2023 ArtikusHG <24320212+ArtikusHG@users.noreply.github.com> - 0.6
+- Add Sunshine udev rules
+
 * Thu Sep 28 2023 Kyle Gospodnetich <me@kylegospodneti.ch> - 0.5
 - Add OpenTabletDriver udev rules
 


### PR DESCRIPTION
This PR fixes issue #119 by adding Sunshine udev rules. These don't seem to be hardware-specific or regularly updating (as per [documentation](https://github.com/LizardByte/Sunshine/blob/master/docs/source/about/usage.rst)), so it's fine to include them as a static file.