### PR TITLE
fix: REVERT feat(udev): add Sunshine udev rules (fix #119)

### DIFF
--- a/files/etc/udev/rules.d/85-sunshine.rules
+++ b/files/etc/udev/rules.d/85-sunshine.rules
@@ -1,1 +1,0 @@
-KERNEL=="uinput", SUBSYSTEM=="misc", OPTIONS+="static_node=uinput", TAG+="uaccess"

--- a/rpmspec/ublue-os-udev-rules.spec
+++ b/rpmspec/ublue-os-udev-rules.spec
@@ -1,7 +1,7 @@
 Name:           ublue-os-udev-rules
 Packager:       ublue-os
 Vendor:         ublue-os
-Version:        0.6
+Version:        0.5
 Release:        1%{?dist}
 Summary:        Additional udev files for device support
 
@@ -45,9 +45,6 @@ cp %{buildroot}%{_datadir}/%{VENDOR}/{%{sub_name}/etc/udev/rules.d,game-devices-
 
 
 %changelog
-* Fri Oct 20 2023 ArtikusHG <24320212+ArtikusHG@users.noreply.github.com> - 0.6
-- Add Sunshine udev rules
-
 * Thu Sep 28 2023 Kyle Gospodnetich <me@kylegospodneti.ch> - 0.5
 - Add OpenTabletDriver udev rules
 


### PR DESCRIPTION
This reverts commit 4d0e776a0537cff8e9c15165e88137bea78e8ed6.

/usr/lib/udev/rules.d/85-sunshine.rules conflicts with the sunshine RPM itself, preventing the install of that package.

I don't think the intent of this PR was to prevent users from using the sunshine RPM.

@ArtikusHG - FYI - I think we need to improve on this.