### PR TITLE
fix(firmware-update): Force metadata refresh

### DIFF
--- a/build/ublue-os-just/10-update.just
+++ b/build/ublue-os-just/10-update.just
@@ -15,7 +15,7 @@ update:
 
 # Update device firmware
 update-firmware:
-  fwupdmgr refresh
+  fwupdmgr refresh --force
   fwupdmgr get-updates
   fwupdmgr update
 


### PR DESCRIPTION
While metadata may be up to date, firmware updates may still be available. When this fails, the script refuses to continue so force a refresh so that newer firmware may still be installed