### PR TITLE
feat: add udev rule to enable usevia.app in supported browsers for Keychron keyboard configuration

### DIFF
--- a/files/etc/udev/rules.d/92-viia.rules
+++ b/files/etc/udev/rules.d/92-viia.rules
@@ -1,0 +1,1 @@
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", MODE="0666", TAG+="uaccess", TAG+="udev-acl"


### PR DESCRIPTION
Keychron keyboard hardware enablement, credit to HikariKnight and Javvy for development and testing