### PR TITLE
feat: add udev rule for an RCM'd Nintendo Switch to allow rootless payload injection

### DIFF
--- a/files/etc/udev/rules.d/10-switch.rules
+++ b/files/etc/udev/rules.d/10-switch.rules
@@ -1,0 +1,1 @@
+SUBSYSTEMS=="usb", ATTRS{manufacturer}=="NVIDIA Corp.", ATTRS{product}=="APX", GROUP="nintendo_switch"


### PR DESCRIPTION
Just to make having to reboot a jigged Switch easier, since I cannot get ns-usbloader to run at all.