### PR TITLE
feat: check just syntax in build action (fix #152)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,21 @@ jobs:
           fi
           echo "alias_tags=${alias_tags[*]}" >> $GITHUB_OUTPUT
 
+      - name: Install just
+        id: install_just
+        uses: extractions/setup-just@v1
+
+      - name: Check just syntax
+        id: check_just_syntax
+        shell: bash
+        run: |
+          for file in build/ublue-os-just/*; do
+            if [ -f "$file" ]; then
+              echo $file
+              just --fmt --check --unstable -f $file || { exit 1; }
+            fi
+          done
+
       # Build image using Buildah action
       - name: Build Image
         id: build_image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
         id: check_just_syntax
         shell: bash
         run: |
-          for file in build/ublue-os-just/*; do
+          for file in build/ublue-os-just/*.just; do
             if [ -f "$file" ]; then
               echo $file
               just --fmt --check --unstable -f $file || { exit 1; }


### PR DESCRIPTION
This PR makes the build action fail when ``just --fmt --check`` fails (#152).

**Note: currently, none of the justfiles we have here pass the formatting check. #156 must be merged first.**