### PR TITLE
feat: update just syntax check to use just-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,20 +38,9 @@ jobs:
           fi
           echo "alias_tags=${alias_tags[*]}" >> $GITHUB_OUTPUT
 
-      - name: Install just
-        id: install_just
-        uses: extractions/setup-just@v1
-
       - name: Check just syntax
         id: check_just_syntax
-        shell: bash
-        run: |
-          for file in build/ublue-os-just/*.just; do
-            if [ -f "$file" ]; then
-              echo $file
-              just --fmt --check --unstable -f $file || { exit 1; }
-            fi
-          done
+        uses: ublue-os/just-action@v1
 
       # Build image using Buildah action
       - name: Build Image


### PR DESCRIPTION
Follow-up of #155. Since we now have [an action to check just syntax](https://github.com/ublue-os/just-action), we can now use this. If this goes smoothly, I will make PRs for all other repos that use just.