### PR TITLE
fix(just): handle non zero exit code update-firmware

### DIFF
--- a/build/ublue-os-just/10-update.just
+++ b/build/ublue-os-just/10-update.just
@@ -67,6 +67,7 @@ update VERB_LEVEL="full":
     fi
 
 # Update device firmware
+[no-exit-message]
 update-firmware:
     fwupdmgr refresh --force
     fwupdmgr get-updates


### PR DESCRIPTION
`just update-firmware` shows an error because of a  non zero exit value. That could lead to confusion by the end user. For example:

```
just update-firmware 
...SNIP...
Devices with the latest available firmware version:
 • UEFI dbx
No updates available
error: Recipe `update-firmware` failed on line 134 with exit code 2
```

The current PR lets just ignore the exit message on the `update-firmware` command, so it would not show an error when the exit code is non zero.

Fixes: https://github.com/ublue-os/bluefin/issues/722