### PR TITLE
feat: add gum helper for choose dialogs

### DIFF
--- a/build/ublue-os-just/build.sh
+++ b/build/ublue-os-just/build.sh
@@ -9,6 +9,7 @@ mkdir -p /tmp/ublue-os/rpmbuild/SOURCES
 cp ${SCRIPT_DIR}/*.just /tmp/ublue-os/rpmbuild/SOURCES
 cp ${SCRIPT_DIR}/ublue-os-just.sh /tmp/ublue-os/rpmbuild/SOURCES
 cp ${SCRIPT_DIR}/ujust /tmp/ublue-os/rpmbuild/SOURCES
+cp ${SCRIPT_DIR}/ugum /tmp/ublue-os/rpmbuild/SOURCES
 
 rpmbuild -ba \
     --define '_topdir /tmp/ublue-os/rpmbuild' \

--- a/build/ublue-os-just/ublue-os-just.spec
+++ b/build/ublue-os-just/ublue-os-just.spec
@@ -1,7 +1,7 @@
 Name:           ublue-os-just
 Packager:       ublue-os
 Vendor:         ublue-os
-Version:        0.9
+Version:        0.10
 Release:        1%{?dist}
 Summary:        ublue-os just integration
 License:        MIT
@@ -20,6 +20,7 @@ Source6:        50-akmods.just
 Source7:        60-custom.just
 Source8:        70-nix.just
 Source9:        ujust
+Source10:       ugum
 
 %global sub_name %{lua:t=string.gsub(rpm.expand("%{NAME}"), "^ublue%-os%-", ""); print(t)}
 
@@ -43,6 +44,7 @@ done
 # Add global "ujust" script to run just with --unstable
 mkdir -p -m0755  %{buildroot}%{_bindir}
 install -Dm755 %{SOURCE9} %{buildroot}%{_bindir}/ujust
+install -Dm755 %{SOURCE10} %{buildroot}%{_bindir}/ugum
 
 %files
 %dir %attr(0755,root,root) %{_datadir}/%{VENDOR}/%{sub_name}
@@ -50,8 +52,12 @@ install -Dm755 %{SOURCE9} %{buildroot}%{_bindir}/ujust
 %attr(0644,root,root) %{_datadir}/%{VENDOR}/%{sub_name}/*.just
 %attr(0644,root,root) %{_datadir}/%{VENDOR}/justfile
 %attr(0755,root,root) %{_bindir}/ujust
+%attr(0755,root,root) %{_bindir}/ugum
 
 %changelog
+* Wed Dec 20 2023 HikariKnight <2557889+HikariKnight@users.noreply.github.com> - 0.10
+- Add ugum, a helper for user input for use in just
+
 * Tue Nov 28 2023 RJ Trujillo <eyecantcu> - 0.9
 - Copy nix justfile to correct location and restore ujust
 

--- a/build/ublue-os-just/ugum
+++ b/build/ublue-os-just/ugum
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+############################################################
+# This is a helper script to provide selectable choices 
+# for just commands and bash scripts in uBlue
+############################################################
+
+# Check if gum is present
+GUM=$(which gum 2>/dev/null)
+
+# If gum is not present
+if [[ -z "$GUM" ]]; then
+    # Change PS3 to our select prompt
+    PS3='Please enter your choice: '
+    options=("$@")
+
+    # Make a select prompt in bash
+    select opt in "${options[@]}"
+    do
+        case $opt in
+            "")
+                # Invalid options print to STDERR and then loops back for the user to select again
+                echo "Invalid option $REPLY" >&2
+                ;;
+            "$opt")
+                echo "$opt"
+                break
+                ;;
+        esac
+    done
+else
+    # If gum is present just pass args to gum
+    $GUM choose "$@"
+fi
+
+# Exit normally to just mimic gum
+exit 0

--- a/build/ublue-os-just/ugum
+++ b/build/ublue-os-just/ugum
@@ -80,12 +80,16 @@ function choose_Fzf () {
     do
         # If the argument does not start with -
         if [[ ! $arg =~ ^- ]]; then
-            OPTIONS="${OPTIONS}$arg\n"
+            if [[ "$OPTIONS" == "" ]]; then
+                OPTIONS="${arg}"
+                continue
+            fi
+            OPTIONS="${OPTIONS}\n${arg}"
         fi
     done
 
     # Make a select prompt using fzf
-    printf "$OPTIONS" | fzf --height="~20%" --prompt="$PROMPT"
+    echo -e $OPTIONS | fzf --height="~20%" --prompt="$PROMPT"
 }
 
 function confirm_Generic () {

--- a/build/ublue-os-just/ugum
+++ b/build/ublue-os-just/ugum
@@ -15,16 +15,29 @@ function nogum () {
     elif [[ "$1" == "choose" ]]; then
         # If choose is the verb then run the choose function and pass all remaining args to it
         choose "${@:2}"
+    elif [[ "$1" == "confirm" ]]; then
+        confirm "${@:2}" 
     fi
 }
 
 function choose () {
     # Change PS3 to our select prompt
     PS3='Please enter your choice: '
-    options=("$@")
+
+    # Make an array to contain all options in
+    OPTIONS=()
+
+    # Parse the arguments for the ones we support and care about
+    for arg in "$@"
+    do
+        # If the argument does not start with -
+        if [[ ! $arg =~ ^- ]]; then
+            OPTIONS+=("$arg")
+        fi
+    done
 
     # Make a select prompt in bash
-    select opt in "${options[@]}"
+    select opt in "${OPTIONS[@]}"
     do
         case $opt in
             "")
@@ -39,6 +52,36 @@ function choose () {
     done 
 }
 
+function confirm () {
+    # Set default prompt
+    PROMPT="Are you sure?"
+
+    # Parse the arguments for the ones we support and care about 
+    for arg in "$@"
+    do
+        if [[ ! $arg =~ ^- ]]; then
+            PROMPT="$arg"
+        fi
+    done
+
+    # Print the prompt and read input
+    read -r -p "$PROMPT [Y/n]: " YESNO
+    case "${YESNO}" in
+        [Yy]*)
+            # Use exit code 0 for yes, just like gum
+            exit 0
+            ;;
+        [Nn]*)
+            # Use exit code 1 for no, just like gum
+            exit 1
+            ;;
+        *)
+            # Default exit code is 0
+            exit 0
+            ;;
+    esac
+}
+
 # If gum is not present
 if [[ -z "$GUM" ]]; then
     nogum "$@"
@@ -46,6 +89,3 @@ else
     # If gum is present just pass args to gum
     $GUM "$@"
 fi
-
-# Exit normally to just mimic gum
-exit 0

--- a/build/ublue-os-just/ugum
+++ b/build/ublue-os-just/ugum
@@ -7,20 +7,36 @@
 # Check if gum is present
 GUM=$(which gum 2>/dev/null)
 
-function nogum () {
+# Check if fzf is installed
+fzf=$(which fzf 2>/dev/null)
+
+function noGum () {
     if [[ -z "$1" ]]; then
         # If no arguments are provided then error with 
         echo "ugum supports only choose or confirm as the first argument!"
         exit 5
     elif [[ "$1" == "choose" ]]; then
-        # If choose is the verb then run the choose function and pass all remaining args to it
-        choose "${@:2}"
+        # If choose is the verb then run the choose function and pass all remaining args to an appropriate handler
+        if [[ ! -z "$fzf" ]]; then
+            # Use fzf for choice selector
+            choose_Fzf "${@:2}"
+        else
+            # Use generic bash selector
+            choose_Generic "${@:2}"
+        fi
     elif [[ "$1" == "confirm" ]]; then
-        confirm "${@:2}" 
+        # If confirm is the verb then run the confirm function and pass all remaining args to an appropriate handler
+        if [[ ! -z "$fzf" ]]; then
+            # Use fzf as a confirm dialog
+            confirm_Fzf "${@:2}"
+        else
+            # Use a generic bash dialog
+            confirm_Generic "${@:2}"
+        fi
     fi
 }
 
-function choose () {
+function choose_Generic () {
     # Change PS3 to our select prompt
     PS3='Please enter your choice: '
 
@@ -52,7 +68,27 @@ function choose () {
     done 
 }
 
-function confirm () {
+function choose_Fzf () {
+    # Change our select prompt
+    PROMPT='Please enter your choice: '
+
+    # Make an array to contain all options in
+    local OPTIONS
+
+    # Parse the arguments for the ones we support and care about
+    for arg in "$@"
+    do
+        # If the argument does not start with -
+        if [[ ! $arg =~ ^- ]]; then
+            OPTIONS="${OPTIONS}$arg\n"
+        fi
+    done
+
+    # Make a select prompt using fzf
+    printf "$OPTIONS" | fzf --height="~20%" --prompt="$PROMPT"
+}
+
+function confirm_Generic () {
     # Set default prompt
     PROMPT="Are you sure?"
 
@@ -66,7 +102,35 @@ function confirm () {
 
     # Print the prompt and read input
     read -r -p "$PROMPT [Y/n]: " YESNO
-    case "${YESNO}" in
+    confirm_Parse "$YESNO"
+}
+
+function confirm_Fzf () {
+    PROMPT=$(confirm_getPrompt "$@")
+
+    # Make the confirm prompt using fzf and read response
+    YESNO=$(echo -e "Yes\nNo" | fzf --height="~20%" --prompt="$PROMPT ")
+    confirm_Parse "$YESNO"
+}
+
+function confirm_getPrompt () {
+    # Set default prompt
+    PROMPT="Are you sure?"
+
+    # Parse the arguments for the ones we support and care about 
+    for arg in "$@"
+    do
+        if [[ ! $arg =~ ^- ]]; then
+            PROMPT="$arg"
+        fi
+    done
+
+    # Return the prompt
+    echo $PROMPT
+}
+
+function confirm_Parse () {
+    case "$@" in
         [Yy]*)
             # Use exit code 0 for yes, just like gum
             exit 0
@@ -84,7 +148,7 @@ function confirm () {
 
 # If gum is not present
 if [[ -z "$GUM" ]]; then
-    nogum "$@"
+    noGum "$@"
 else
     # If gum is present just pass args to gum
     $GUM "$@"

--- a/build/ublue-os-just/ugum
+++ b/build/ublue-os-just/ugum
@@ -89,7 +89,7 @@ function choose_Generic () {
 
 function choose_Fzf () {
     # Change our select prompt
-    PROMPT='Please enter your choice: '
+    PROMPT='Please select your choice: '
 
     # Make an array to contain all options in
     local OPTIONS

--- a/build/ublue-os-just/ugum
+++ b/build/ublue-os-just/ugum
@@ -4,11 +4,30 @@
 # for just commands and bash scripts that want to use gum in uBlue
 ##################################################################
 
+# Supported menu handlers
+SUPPORTED_HANDLERS=(
+    "fzf"
+)
+
 # Check if gum is present
 GUM=$(which gum 2>/dev/null)
 
-# Check if fzf is installed
-fzf=$(which fzf 2>/dev/null)
+# Check if fzf is installed and set it as the handler
+FALLBACK_HANDLER=$(which fzf 2>/dev/null)
+HANDLER=""
+if [[ ! -z $FALLBACK_HANDLER ]]; then
+    HANDLER="fzf"
+fi
+
+# If $MENU is set
+if [[ ! -z $MENU ]]; then
+    for BIN in "${SUPPORTED_HANDLERS[@]}"
+    do
+        if [[ "$BIN" == "$MENU" ]]; then
+            HANDLER=$BIN
+        fi
+    done
+fi
 
 function noGum () {
     if [[ -z "$1" ]]; then
@@ -17,7 +36,7 @@ function noGum () {
         exit 5
     elif [[ "$1" == "choose" ]]; then
         # If choose is the verb then run the choose function and pass all remaining args to an appropriate handler
-        if [[ ! -z "$fzf" ]]; then
+        if [[ "$HANDLER" == "fzf" ]]; then
             # Use fzf for choice selector
             choose_Fzf "${@:2}"
         else
@@ -26,7 +45,7 @@ function noGum () {
         fi
     elif [[ "$1" == "confirm" ]]; then
         # If confirm is the verb then run the confirm function and pass all remaining args to an appropriate handler
-        if [[ ! -z "$fzf" ]]; then
+        if [[ "$HANDLER" == "fzf" ]]; then
             # Use fzf as a confirm dialog
             confirm_Fzf "${@:2}"
         else

--- a/build/ublue-os-just/ugum
+++ b/build/ublue-os-just/ugum
@@ -1,14 +1,24 @@
 #!/usr/bin/env bash
-############################################################
-# This is a helper script to provide selectable choices 
-# for just commands and bash scripts in uBlue
-############################################################
+##################################################################
+# This is a helper script to provide a basic fallback replacement 
+# for just commands and bash scripts that want to use gum in uBlue
+##################################################################
 
 # Check if gum is present
 GUM=$(which gum 2>/dev/null)
 
-# If gum is not present
-if [[ -z "$GUM" ]]; then
+function nogum () {
+    if [[ -z "$1" ]]; then
+        # If no arguments are provided then error with 
+        echo "ugum supports only choose or confirm as the first argument!"
+        exit 5
+    elif [[ "$1" == "choose" ]]; then
+        # If choose is the verb then run the choose function and pass all remaining args to it
+        choose "${@:2}"
+    fi
+}
+
+function choose () {
     # Change PS3 to our select prompt
     PS3='Please enter your choice: '
     options=("$@")
@@ -26,10 +36,15 @@ if [[ -z "$GUM" ]]; then
                 break
                 ;;
         esac
-    done
+    done 
+}
+
+# If gum is not present
+if [[ -z "$GUM" ]]; then
+    nogum "$@"
 else
     # If gum is present just pass args to gum
-    $GUM choose "$@"
+    $GUM "$@"
 fi
 
 # Exit normally to just mimic gum


### PR DESCRIPTION
This should help start the process of addressing #148 as it will let us provide basic replacement for gum on systems that lack it with minimal options which in turn lets us shrink down the amount of just commands we have greatly.

Currently it only does choose dialogs, but before merging i want to implement the confirm dialog too.
Return values will be identical to what you would expect from gum so in the most basic use cases it will be a 1:1 drop in, assuming you do not need anything more fancy than the defaults from gum.