### PR TITLE
feat(just): added log messages shortcut from journalctl to 00-default.just

### DIFF
--- a/build/ublue-os-just/00-default.just
+++ b/build/ublue-os-just/00-default.just
@@ -13,6 +13,14 @@ _default:
 bios:
     systemctl reboot --firmware-setup
 
+# Show all messages from this boot
+logs-this-boot:
+    sudo journalctl -b 0
+
+# Show all messages from last boot
+logs-last-boot:
+    sudo journalctl -b -1
+
 # Change the user's shell
 chsh new_shell:
     #!/usr/bin/env bash


### PR DESCRIPTION
I think it would be pretty handy if there was like a collection of shortcuts for log messages/crash reports.