### PR TITLE
feat(just): combine several just commands into toggles or choices

### DIFF
--- a/build/ublue-os-just/00-default.just
+++ b/build/ublue-os-just/00-default.just
@@ -9,7 +9,7 @@ bios:
 
 # Change the user's shell
 chsh new_shell:
-    #!/usr/bin/env bash
+    #!/usr/bin/bash
     set -euo pipefail
     if [ "{{ shell }}" = "{{ new_shell }}" ] ; then
       printf "Your shell is already set to %s.\n" "{{ new_shell }}"
@@ -24,7 +24,7 @@ chsh new_shell:
 
 # Regenerate GRUB config, useful in dual-boot scenarios where a second operating system isn't listed
 regenerate-grub:
-    #!/usr/bin/env bash
+    #!/usr/bin/bash
     if [ -d /sys/firmware/efi ]; then
       sudo grub2-mkconfig -o /etc/grub2-efi.cfg
     else
@@ -42,7 +42,7 @@ enroll-secure-boot-key:
 
 # Install or uninstall distrobox-git
 setup-distrobox-git:
-    #!/usr/bin/env bash
+    #!/usr/bin/bash
     echo 'Which version of Distrobox do you want to use?'
     OPTION=$(ugum choose "Latest distrobox-git snapshot" "uBlue provided version")
     if [ "$OPTION" == "Latest distrobox-git snapshot" ]; then

--- a/build/ublue-os-just/00-default.just
+++ b/build/ublue-os-just/00-default.just
@@ -40,15 +40,21 @@ enroll-secure-boot-key:
     echo 'Enter password "ublue-os" if prompted after your user password.'
     sudo mokutil --import /etc/pki/akmods/certs/akmods-ublue.der
 
-# Upgrade Distrobox to the latest git version
-distrobox-git:
-    echo 'Installing latest git snapshot of Distrobox...'
-    curl -s https://raw.githubusercontent.com/89luca89/distrobox/main/install | sh -s -- --next --prefix ~/.local
-
-# Downgrades Distrobox to the Fedora version
-remove-distrobox-git:
-    echo 'Uninstalling latest git snapshot of Distrobox...'
-    curl -s https://raw.githubusercontent.com/89luca89/distrobox/main/uninstall | sh -s -- --prefix ~/.local
+# Configures distrobox-git
+setup-distrobox-git:
+    #!/usr/bin/env bash
+    echo 'Which version of Distrobox do you want to use?'
+    OPTION=$(ugum choose "Latest distrobox-git snapshot" "uBlue provided version")
+    if [ "$OPTION" == "Latest distrobox-git snapshot" ]; then
+      echo 'Installing latest git snapshot of Distrobox...'
+      curl -s https://raw.githubusercontent.com/89luca89/distrobox/main/install | sh -s -- --next --prefix ~/.local
+    elif [ "$OPTION" == "uBlue provided version" ]; then
+      echo 'Uninstalling latest git snapshot of Distrobox...'
+      curl -s https://raw.githubusercontent.com/89luca89/distrobox/main/uninstall | sh -s -- --prefix ~/.local
+    else
+      echo 'Cancelling...'
+      exit 0
+    fi
 
 # Removes homebrew from system
 brew-remove:

--- a/build/ublue-os-just/00-default.just
+++ b/build/ublue-os-just/00-default.just
@@ -40,7 +40,7 @@ enroll-secure-boot-key:
     echo 'Enter password "ublue-os" if prompted after your user password.'
     sudo mokutil --import /etc/pki/akmods/certs/akmods-ublue.der
 
-# Configures distrobox-git
+# Configure distrobox-git
 setup-distrobox-git:
     #!/usr/bin/env bash
     echo 'Which version of Distrobox do you want to use?'

--- a/build/ublue-os-just/00-default.just
+++ b/build/ublue-os-just/00-default.just
@@ -40,7 +40,7 @@ enroll-secure-boot-key:
     echo 'Enter password "ublue-os" if prompted after your user password.'
     sudo mokutil --import /etc/pki/akmods/certs/akmods-ublue.der
 
-# Configure distrobox-git
+# Install or uninstall distrobox-git
 setup-distrobox-git:
     #!/usr/bin/env bash
     echo 'Which version of Distrobox do you want to use?'
@@ -57,6 +57,6 @@ setup-distrobox-git:
     fi
 
 # Removes homebrew from system
-brew-remove:
+remove-brew:
     echo "Removing homebrew ..."
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/uninstall.sh)"

--- a/build/ublue-os-just/00-default.just
+++ b/build/ublue-os-just/00-default.just
@@ -39,6 +39,8 @@ changelogs:
 enroll-secure-boot-key:
     echo 'Enter password "ublue-os" if prompted after your user password.'
     sudo mokutil --import /etc/pki/akmods/certs/akmods-ublue.der
+    echo 'When you reboot your computer, follow the instructions to start MOK util'
+    echo 'by pressing a key, then enroll the secure boot key and enter "ublue-os" as the password'
 
 # Install or uninstall distrobox-git
 setup-distrobox-git:

--- a/build/ublue-os-just/10-update.just
+++ b/build/ublue-os-just/10-update.just
@@ -73,26 +73,29 @@ update-firmware:
     fwupdmgr get-updates
     fwupdmgr update
 
-# Disable all auto-update timers
-disable-updates:
+# Turn automatic updates on or off
+toggle-updates:
     #!/usr/bin/env bash
-    if systemctl is-enabled ublue-update.timer | grep -q enabled;
-    then
-      sudo systemctl disable ublue-update.timer
-    elif systemctl is-enabled flatpak-system-update.timer | grep -q enabled;
-    then
-      sudo systemctl disable --now flatpak-system-update.timer rpm-ostreed-automatic.timer
-      systemctl disable --now --user flatpak-user-update.timer
+    CURRENT_STATE="Disabled"
+    if systemctl is-enabled ublue-update.timer | grep -q enabled; then
+      CURRENT_STATE="Enabled"
     fi
-
-# Enable all auto-update timers
-enable-updates:
-    #!/usr/bin/env bash
-    if systemctl is-enabled ublue-update.timer | grep -q disabled;
-    then
-       sudo systemctl enable ublue-update.timer
-    elif systemctl is-enabled flatpak-system-update.timer | grep -q disabled;
-    then
-      sudo systemctl enable --now flatpak-system-update.timer rpm-ostreed-automatic.timer
-      systemctl enable --now --user flatpak-user-update.timer
+    echo "Automatic updates are currently ${CURRENT_STATE}"
+    echo "Enable or Disable automatic updates?"
+    OPTION=$(ugum choose Enable Disable)
+    if [ "$OPTION" == "Enable" ]; then
+      sudo systemctl enable ublue-update.timer
+      if systemctl is-enabled flatpak-system-update.timer | grep -q disabled; then
+        sudo systemctl enable --now flatpak-system-update.timer rpm-ostreed-automatic.timer
+        systemctl enable --now --user flatpak-user-update.timer
+      fi
+    elif [ "$OPTION" == "Disable" ]; then
+      sudo systemctl disable ublue-update.timer
+      if systemctl is-enabled flatpak-system-update.timer | grep -q enabled; then
+        sudo systemctl disable --now flatpak-system-update.timer rpm-ostreed-automatic.timer
+        systemctl disable --now --user flatpak-user-update.timer
+      fi
+    else
+      echo 'Exiting...'
+      exit 0
     fi

--- a/build/ublue-os-just/10-update.just
+++ b/build/ublue-os-just/10-update.just
@@ -4,7 +4,7 @@ alias upgrade := update
 
 # Update system, flatpaks, and containers all at once
 update VERB_LEVEL="full":
-    #!/usr/bin/env bash
+    #!/usr/bin/bash
     if systemctl is-enabled ublue-update.timer | grep -q enabled;
     then
       echo "Starting the ublue-update service"
@@ -79,7 +79,7 @@ alias auto-update := toggle-updates
 
 # Turn automatic updates on or off
 toggle-updates ARG="prompt":
-    #!/usr/bin/env bash
+    #!/usr/bin/bash
     CURRENT_STATE="Disabled"
     if systemctl is-enabled ublue-update.timer | grep -q enabled; then
       CURRENT_STATE="Enabled"

--- a/build/ublue-os-just/10-update.just
+++ b/build/ublue-os-just/10-update.just
@@ -82,7 +82,7 @@ toggle-updates ARG="prompt":
     fi
     bold=$(tput bold)
     normal=$(tput sgr0)
-    OPTION={{ARG}}
+    OPTION={{ ARG }}
     if [ "$OPTION" == "prompt" ]; then
       echo "Automatic updates are currently: ${bold}${CURRENT_STATE}${normal}"
       echo "Enable or Disable automatic updates?"

--- a/build/ublue-os-just/10-update.just
+++ b/build/ublue-os-just/10-update.just
@@ -75,6 +75,7 @@ update-firmware:
     fwupdmgr update
 
 alias auto-update := toggle-updates
+
 # Turn automatic updates on or off
 toggle-updates ARG="prompt":
     #!/usr/bin/env bash

--- a/build/ublue-os-just/10-update.just
+++ b/build/ublue-os-just/10-update.just
@@ -74,7 +74,7 @@ update-firmware:
     fwupdmgr update
 
 # Turn automatic updates on or off
-toggle-updates:
+toggle-updates ARG="prompt":
     #!/usr/bin/env bash
     CURRENT_STATE="Disabled"
     if systemctl is-enabled ublue-update.timer | grep -q enabled; then
@@ -82,16 +82,25 @@ toggle-updates:
     fi
     bold=$(tput bold)
     normal=$(tput sgr0)
-    echo "Automatic updates are currently: ${bold}${CURRENT_STATE}${normal}"
-    echo "Enable or Disable automatic updates?"
-    OPTION=$(ugum choose Enable Disable)
-    if [ "$OPTION" == "Enable" ]; then
+    OPTION={{ARG}}
+    if [ "$OPTION" == "prompt" ]; then
+      echo "Automatic updates are currently: ${bold}${CURRENT_STATE}${normal}"
+      echo "Enable or Disable automatic updates?"
+      OPTION=$(ugum choose Enable Disable)
+    elif [ "$OPTION" == "help" ]; then
+      echo "Usage: ujust toggle-updates <option>"
+      echo "  <option>: Specify the quick option - 'enable' or 'disable'"
+      echo "  Use 'enable' to Enable automatic updates."
+      echo "  Use 'disable' to Disable automatic updates."
+      exit 0
+    fi
+    if [ "${OPTION,,}" == "Enable" ]; then
       sudo systemctl enable ublue-update.timer
       if systemctl is-enabled flatpak-system-update.timer | grep -q disabled; then
         sudo systemctl enable --now flatpak-system-update.timer rpm-ostreed-automatic.timer
         systemctl enable --now --user flatpak-user-update.timer
       fi
-    elif [ "$OPTION" == "Disable" ]; then
+    elif [ "${OPTION,,}" == "Disable" ]; then
       sudo systemctl disable ublue-update.timer
       if systemctl is-enabled flatpak-system-update.timer | grep -q enabled; then
         sudo systemctl disable --now flatpak-system-update.timer rpm-ostreed-automatic.timer

--- a/build/ublue-os-just/10-update.just
+++ b/build/ublue-os-just/10-update.just
@@ -1,6 +1,7 @@
 # vim: set ft=make :
 
 alias upgrade := update
+
 # Update system, flatpaks, and containers all at once
 update VERB_LEVEL="full":
     #!/usr/bin/env bash

--- a/build/ublue-os-just/10-update.just
+++ b/build/ublue-os-just/10-update.just
@@ -80,7 +80,9 @@ toggle-updates:
     if systemctl is-enabled ublue-update.timer | grep -q enabled; then
       CURRENT_STATE="Enabled"
     fi
-    echo "Automatic updates are currently ${CURRENT_STATE}"
+    bold=$(tput bold)
+    normal=$(tput sgr0)
+    echo "Automatic updates are currently: ${bold}${CURRENT_STATE}${normal}"
     echo "Enable or Disable automatic updates?"
     OPTION=$(ugum choose Enable Disable)
     if [ "$OPTION" == "Enable" ]; then
@@ -95,7 +97,4 @@ toggle-updates:
         sudo systemctl disable --now flatpak-system-update.timer rpm-ostreed-automatic.timer
         systemctl disable --now --user flatpak-user-update.timer
       fi
-    else
-      echo 'Exiting...'
-      exit 0
     fi

--- a/build/ublue-os-just/10-update.just
+++ b/build/ublue-os-just/10-update.just
@@ -78,7 +78,7 @@ update-firmware:
 alias auto-update := toggle-updates
 
 # Turn automatic updates on or off
-toggle-updates ARG="prompt":
+toggle-updates ACTION="prompt":
     #!/usr/bin/bash
     CURRENT_STATE="Disabled"
     if systemctl is-enabled ublue-update.timer | grep -q enabled; then
@@ -86,7 +86,7 @@ toggle-updates ARG="prompt":
     fi
     bold=$(tput bold)
     normal=$(tput sgr0)
-    OPTION={{ ARG }}
+    OPTION={{ ACTION }}
     if [ "$OPTION" == "prompt" ]; then
       echo "Automatic updates are currently: ${bold}${CURRENT_STATE}${normal}"
       echo "Enable or Disable automatic updates?"

--- a/build/ublue-os-just/10-update.just
+++ b/build/ublue-os-just/10-update.just
@@ -98,13 +98,13 @@ toggle-updates ARG="prompt":
       echo "  Use 'disable' to Disable automatic updates."
       exit 0
     fi
-    if [ "${OPTION,,}" == "Enable" ]; then
+    if [ "${OPTION,,}" == "enable" ]; then
       sudo systemctl enable ublue-update.timer
       if systemctl is-enabled flatpak-system-update.timer | grep -q disabled; then
         sudo systemctl enable --now flatpak-system-update.timer rpm-ostreed-automatic.timer
         systemctl enable --now --user flatpak-user-update.timer
       fi
-    elif [ "${OPTION,,}" == "Disable" ]; then
+    elif [ "${OPTION,,}" == "disable" ]; then
       sudo systemctl disable ublue-update.timer
       if systemctl is-enabled flatpak-system-update.timer | grep -q enabled; then
         sudo systemctl disable --now flatpak-system-update.timer rpm-ostreed-automatic.timer

--- a/build/ublue-os-just/10-update.just
+++ b/build/ublue-os-just/10-update.just
@@ -1,5 +1,6 @@
 # vim: set ft=make :
 
+alias upgrade := update
 # Update system, flatpaks, and containers all at once
 update VERB_LEVEL="full":
     #!/usr/bin/env bash
@@ -73,6 +74,7 @@ update-firmware:
     fwupdmgr get-updates
     fwupdmgr update
 
+alias auto-update := toggle-updates
 # Turn automatic updates on or off
 toggle-updates ARG="prompt":
     #!/usr/bin/env bash

--- a/build/ublue-os-just/20-clean.just
+++ b/build/ublue-os-just/20-clean.just
@@ -2,7 +2,7 @@
 
 # Clean up old containers and flatpaks
 clean-system:
-    #!/usr/bin/env bash
+    #!/usr/bin/bash
     podman system prune -a
     flatpak uninstall --unused
     rpm-ostree cleanup -bm

--- a/build/ublue-os-just/30-distrobox.just
+++ b/build/ublue-os-just/30-distrobox.just
@@ -7,7 +7,7 @@ distrobox-arch:
 
 # Create a Bazzite-Arch container
 distrobox-bazzite:
-    #!/usr/bin/env bash
+    #!/usr/bin/bash
     echo 'Creating Bazzite distrobox ...'
     if command -v /usr/bin/mutter > /dev/null; then
       distrobox-create --unshare-netns --nvidia --image ghcr.io/ublue-os/bazzite-arch-gnome --name bazzite-arch -Y

--- a/build/ublue-os-just/40-nvidia.just
+++ b/build/ublue-os-just/40-nvidia.just
@@ -1,14 +1,24 @@
 # vim: set ft=make :
 
 # Configure the Nvidia driver
-configure-nvidia:
+configure-nvidia ARG="prompt":
     #!/usr/bin/env bash
     bold=$(tput bold)
     normal=$(tput sgr0)
-    echo "${bold}Configuring Nvidia drivers${normal}"
-    echo 'What would you like to do?'
-    OPTION=$(ugum choose "Set needed kernel arguments" "Test CUDA support" "Enable Nvidia VAAPI in Firefox Flatpak")
-    if [ "$OPTION" == "Set needed kernel arguments" ]; then
+    OPTION={{ARG}}
+    if [ "$OPTION" == "prompt" ]; then
+      echo "${bold}Configuring Nvidia drivers${normal}"
+      echo 'What would you like to do?'
+      OPTION=$(ugum choose "Set needed kernel arguments" "Test CUDA support" "Enable Nvidia VAAPI in Firefox Flatpak")
+    elif [ "$OPTION" == "help" ]; then
+      echo "Usage: ujust configure-nvidia <option>"
+      echo "  <option>: Specify the quick option - 'kargs', 'test-cuda' or 'firefox-vaapi'"
+      echo "  Use 'kargs' to Set needed kernel arguments"
+      echo "  Use 'test-cuda' to Test CUDA support"
+      echo "  Use 'firefox-vaapi' to Enable Nvidia VAAPI in Firefox Flatpak."
+      exit 0
+    fi
+    if [ "$OPTION" == "Set needed kernel arguments" ] || [ "${OPTION,,}" == "kargs" ]; then
       if command -v nvidia-smi; then
         rpm-ostree kargs \
           --append-if-missing=rd.driver.blacklist=nouveau \
@@ -18,7 +28,7 @@ configure-nvidia:
       else
         echo 'You do not appear to be on a Nvidia image, please refer to the README for your uBlue-OS image.'
       fi
-    elif [ "$OPTION" == "Test CUDA support" ]; then
+    elif [ "$OPTION" == "Test CUDA support" ] || [ "${OPTION,,}" == "test-cuda" ]; then
       if lsmod | grep -wq "nvidia"; then
         podman run \
           --user 1000:1000 \
@@ -30,7 +40,7 @@ configure-nvidia:
       else
         echo 'The Nvidia kernel module is not loaded. You may be using secure boot without the needed signing key, lacking the needed kargs, or may not be on a Nvidia image. See "just enroll-secure-boot-key" and "just nvidia-set-kargs".'
       fi
-    elif [ "$OPTION" == "Enable Nvidia VAAPI in Firefox Flatpak" ]; then
+    elif [ "$OPTION" == "Enable Nvidia VAAPI in Firefox Flatpak" ] || [ "${OPTION,,}" == "firefox-vaapi" ]; then
       if lsmod | grep -wq "nvidia"; then
         flatpak override \
           --user \

--- a/build/ublue-os-just/40-nvidia.just
+++ b/build/ublue-os-just/40-nvidia.just
@@ -1,5 +1,6 @@
 # vim: set ft=make :
 
+alias nvidia := configure-nvidia
 # Configure the Nvidia driver
 configure-nvidia ARG="prompt":
     #!/usr/bin/env bash

--- a/build/ublue-os-just/40-nvidia.just
+++ b/build/ublue-os-just/40-nvidia.just
@@ -58,3 +58,17 @@ configure-nvidia ACTION="prompt":
         echo 'The Nvidia kernel module is not loaded. You may be using secure boot without the needed signing key, lacking the needed kargs, or may not be on a Nvidia image. See "just enroll-secure-boot-key" and "just nvidia-set-kargs".'
       fi
     fi
+
+# Switch between Nvidia image and NVK
+toggle-nvk:
+    #!/usr/bin/bash
+    CURRENT_IMAGE=$(rpm-ostree status -b --json | jq -r '.deployments[0]."container-image-reference"' | sed -E 's/^.+\/(.+:.+)$/\1/')
+    CURRENT_URI=$(rpm-ostree status -b --json | jq -r '.deployments[0]."container-image-reference"' | sed -E 's/^(.+\/).+:.+$/\1/')
+    NEW_IMAGE=$CURRENT_IMAGE
+    if [[ "$CURRENT_IMAGE" =~ "nvidia" ]]; then
+      NEW_IMAGE=${CURRENT_IMAGE/-nvidia/}
+    else
+      NEW_IMAGE=${CURRENT_IMAGE/:/-nvidia:}
+    fi
+    echo "Rebasing to ${NEW_IMAGE}"
+    rpm-ostree rebase ${CURRENT_URI}${NEW_IMAGE}

--- a/build/ublue-os-just/40-nvidia.just
+++ b/build/ublue-os-just/40-nvidia.just
@@ -5,7 +5,7 @@ configure-nvidia ARG="prompt":
     #!/usr/bin/env bash
     bold=$(tput bold)
     normal=$(tput sgr0)
-    OPTION={{ARG}}
+    OPTION={{ ARG }}
     if [ "$OPTION" == "prompt" ]; then
       echo "${bold}Configuring Nvidia drivers${normal}"
       echo 'What would you like to do?'

--- a/build/ublue-os-just/40-nvidia.just
+++ b/build/ublue-os-just/40-nvidia.just
@@ -4,7 +4,7 @@ alias nvidia := configure-nvidia
 
 # Configure the Nvidia driver
 configure-nvidia ARG="prompt":
-    #!/usr/bin/env bash
+    #!/usr/bin/bash
     bold=$(tput bold)
     normal=$(tput sgr0)
     OPTION={{ ARG }}

--- a/build/ublue-os-just/40-nvidia.just
+++ b/build/ublue-os-just/40-nvidia.just
@@ -1,47 +1,48 @@
 # vim: set ft=make :
 
-# Set needed kernel arguments for Nvidia GPUs
-nvidia-set-kargs:
+# Configure the Nvidia driver
+configure-nvidia:
     #!/usr/bin/env bash
-    if command -v nvidia-smi; then
-      rpm-ostree kargs \
-        --append-if-missing=rd.driver.blacklist=nouveau \
-        --append-if-missing=modprobe.blacklist=nouveau \
-        --append-if-missing=nvidia-drm.modeset=1 \
-        --delete-if-present=nomodeset
-    else
-      echo 'You do not appear to be on a Nvidia image, please refer to the README for your uBlue-OS image.'
-    fi
-
-# Test CUDA support for Nvidia GPUs
-nvidia-test-cuda:
-    #!/usr/bin/env bash
-    if lsmod | grep -wq "nvidia"; then
-      podman run \
-        --user 1000:1000 \
-        --security-opt=no-new-privileges \
-        --cap-drop=ALL \
-        --security-opt label=type:nvidia_container_t  \
-        --device=nvidia.com/gpu=all \
-        docker.io/nvidia/samples:vectoradd-cuda11.2.1
-    else
-      echo 'The Nvidia kernel module is not loaded. You may be using secure boot without the needed signing key, lacking the needed kargs, or may not be on a Nvidia image. See "just enroll-secure-boot-key" and "just nvidia-set-kargs".'
-    fi
-
-# Enable VAAPI in Firefox Flatpak for Nvidia GPUs
-nvidia-setup-firefox-vaapi:
-    #!/usr/bin/env bash
-    if lsmod | grep -wq "nvidia"; then
-      flatpak override \
-        --user \
-        --filesystem=host-os \
-        --env=LIBVA_DRIVER_NAME=nvidia \
-        --env=LIBVA_DRIVERS_PATH=/run/host/usr/lib64/dri \
-        --env=LIBVA_MESSAGING_LEVEL=1 \
-        --env=MOZ_DISABLE_RDD_SANDBOX=1 \
-        --env=NVD_BACKEND=direct \
-        --env=MOZ_ENABLE_WAYLAND=1 \
-        org.mozilla.firefox
-    else
-      echo 'The Nvidia kernel module is not loaded. You may be using secure boot without the needed signing key, lacking the needed kargs, or may not be on a Nvidia image. See "just enroll-secure-boot-key" and "just nvidia-set-kargs".'
+    bold=$(tput bold)
+    normal=$(tput sgr0)
+    echo "${bold}Configuring Nvidia drivers${normal}"
+    echo 'What would you like to do?'
+    OPTION=$(ugum choose "Set needed kernel arguments" "Test CUDA support" "Enable Nvidia VAAPI in Firefox Flatpak")
+    if [ "$OPTION" == "Set needed kernel arguments" ]; then
+      if command -v nvidia-smi; then
+        rpm-ostree kargs \
+          --append-if-missing=rd.driver.blacklist=nouveau \
+          --append-if-missing=modprobe.blacklist=nouveau \
+          --append-if-missing=nvidia-drm.modeset=1 \
+          --delete-if-present=nomodeset
+      else
+        echo 'You do not appear to be on a Nvidia image, please refer to the README for your uBlue-OS image.'
+      fi
+    elif [ "$OPTION" == "Test CUDA support" ]; then
+      if lsmod | grep -wq "nvidia"; then
+        podman run \
+          --user 1000:1000 \
+          --security-opt=no-new-privileges \
+          --cap-drop=ALL \
+          --security-opt label=type:nvidia_container_t  \
+          --device=nvidia.com/gpu=all \
+          docker.io/nvidia/samples:vectoradd-cuda11.2.1
+      else
+        echo 'The Nvidia kernel module is not loaded. You may be using secure boot without the needed signing key, lacking the needed kargs, or may not be on a Nvidia image. See "just enroll-secure-boot-key" and "just nvidia-set-kargs".'
+      fi
+    elif [ "$OPTION" == "Enable Nvidia VAAPI in Firefox Flatpak" ]; then
+      if lsmod | grep -wq "nvidia"; then
+        flatpak override \
+          --user \
+          --filesystem=host-os \
+          --env=LIBVA_DRIVER_NAME=nvidia \
+          --env=LIBVA_DRIVERS_PATH=/run/host/usr/lib64/dri \
+          --env=LIBVA_MESSAGING_LEVEL=1 \
+          --env=MOZ_DISABLE_RDD_SANDBOX=1 \
+          --env=NVD_BACKEND=direct \
+          --env=MOZ_ENABLE_WAYLAND=1 \
+          org.mozilla.firefox
+      else
+        echo 'The Nvidia kernel module is not loaded. You may be using secure boot without the needed signing key, lacking the needed kargs, or may not be on a Nvidia image. See "just enroll-secure-boot-key" and "just nvidia-set-kargs".'
+      fi
     fi

--- a/build/ublue-os-just/40-nvidia.just
+++ b/build/ublue-os-just/40-nvidia.just
@@ -1,6 +1,7 @@
 # vim: set ft=make :
 
 alias nvidia := configure-nvidia
+
 # Configure the Nvidia driver
 configure-nvidia ARG="prompt":
     #!/usr/bin/env bash

--- a/build/ublue-os-just/40-nvidia.just
+++ b/build/ublue-os-just/40-nvidia.just
@@ -3,11 +3,11 @@
 alias nvidia := configure-nvidia
 
 # Configure the Nvidia driver
-configure-nvidia ARG="prompt":
+configure-nvidia ACTION="prompt":
     #!/usr/bin/bash
     bold=$(tput bold)
     normal=$(tput sgr0)
-    OPTION={{ ARG }}
+    OPTION={{ ACTION }}
     if [ "$OPTION" == "prompt" ]; then
       echo "${bold}Configuring Nvidia drivers${normal}"
       echo 'What would you like to do?'

--- a/build/ublue-os-just/50-akmods.just
+++ b/build/ublue-os-just/50-akmods.just
@@ -1,29 +1,43 @@
 # vim: set ft=make :
 
-# Use stock gamepad drivers
-use-stock-gamepads:
+# Configure gamepad drivers
+configure-gamepads:
     #!/usr/bin/env bash
-    sudo bash -c '> /etc/modprobe.d/xone.conf'
-    sudo bash -c '> /etc/modprobe.d/xpadneo.conf'
-    sudo bash -c '> /etc/modprobe.d/xpad-noone-blacklist.conf'
-    sudo bash -c '> /etc/modules-load.d/xpad-noone.conf'
+    echo 'Which driver do you want to use?'
+    echo 'uBlue (default and good for official controllers):'
+    echo '  xpad (with no xbox one support), xpadneo, xone'
+    echo 'Stock:'
+    echo '  Xbox one support and fixes a lot of third party controllers'
+    OPTION=$(ugum choose uBlue Stock)
+    if [ "$OPTION" == "uBlue" ]; then
+      sudo rm -f /etc/modprobe.d/xone.conf
+      sudo rm -f /etc/modprobe.d/xpadneo.conf
+      sudo rm -f /etc/modprobe.d/xpad-noone-blacklist.conf
+      sudo rm -f /etc/modules-load.d/xpad-noone.conf
+    elif [ "$OPTION" == "Stock" ]; then
+      sudo bash -c '> /etc/modprobe.d/xone.conf'
+      sudo bash -c '> /etc/modprobe.d/xpadneo.conf'
+      sudo bash -c '> /etc/modprobe.d/xpad-noone-blacklist.conf'
+      sudo bash -c '> /etc/modules-load.d/xpad-noone.conf'
+    else
+      echo 'Exiting...'
+      exit 0
+    fi
 
-# Use uBlue gamepad drivers (Default)
-use-ublue-gamepads:
+# Configure Broadcom WL driver (Enabling WL breaks numerous other Wi-Fi adapters)
+configure-broadcom-wl:
     #!/usr/bin/env bash
-    sudo rm -f /etc/modprobe.d/xone.conf
-    sudo rm -f /etc/modprobe.d/xpadneo.conf
-    sudo rm -f /etc/modprobe.d/xpad-noone-blacklist.conf
-    sudo rm -f /etc/modules-load.d/xpad-noone.conf
-
-# Disable Broadcom WL driver (Default - WL breaks numerous other Wi-Fi adapters)
-disable-broadcom-wl:
-    #!/usr/bin/env bash
-    sudo bash -c '> /etc/modules-load.d/broadcom-wl-blacklist.conf'
-    sudo bash -c 'echo "blacklist wl" > /etc/modules-load.d/default-disable-broadcom-wl.conf'
-
-# Use Broadcom WL driver
-use-broadcom-wl:
-    #!/usr/bin/env bash
-    sudo rm -f /etc/modprobe.d/broadcom-wl-blacklist.conf
-    sudo rm -f /etc/modprobe.d/default-disable-broadcom-wl.conf
+    echo 'Enabling Broadcom WL driver will break numerous other Wi-Fi adapters.'
+    echo 'Enable or Disable Broadcom Wl?'
+    OPTION=$(ugum choose Enable Disable)
+    if [ "$OPTION" == "Enable" ]; then
+      sudo rm -f /etc/modprobe.d/broadcom-wl-blacklist.conf
+      sudo rm -f /etc/modprobe.d/default-disable-broadcom-wl.conf
+    elif [ "$OPTION" == "Disable" ]; then
+      sudo bash -c '> /etc/modules-load.d/broadcom-wl-blacklist.conf'
+      sudo bash -c 'echo "blacklist wl" > /etc/modules-load.d/default-disable-broadcom-wl.conf'
+    else
+      echo 'Exiting...'
+      exit 0
+    fi
+    

--- a/build/ublue-os-just/50-akmods.just
+++ b/build/ublue-os-just/50-akmods.just
@@ -4,7 +4,7 @@ alias gamepads := configure-gamepads
 
 # Configure gamepad drivers
 configure-gamepads ARG="prompt":
-    #!/usr/bin/env bash
+    #!/usr/bin/bash
     bold=$(tput bold)
     normal=$(tput sgr0)
     OPTION={{ ARG }}
@@ -38,7 +38,7 @@ alias broadcom-wl := configure-broadcom-wl
 
 # Configure Broadcom WL driver (Enabling WL breaks numerous other Wi-Fi adapters)
 configure-broadcom-wl ARG="prompt":
-    #!/usr/bin/env bash
+    #!/usr/bin/bash
     bold=$(tput bold)
     normal=$(tput sgr0)
     OPTION={{ ARG }}

--- a/build/ublue-os-just/50-akmods.just
+++ b/build/ublue-os-just/50-akmods.just
@@ -24,6 +24,9 @@ configure-gamepads:
 # Configure Broadcom WL driver (Enabling WL breaks numerous other Wi-Fi adapters)
 configure-broadcom-wl:
     #!/usr/bin/env bash
+    bold=$(tput bold)
+    normal=$(tput sgr0)
+    echo "${bold}Configuring Broadcom Wi-Fi${normal}"
     echo 'Enabling Broadcom WL driver will break numerous other Wi-Fi adapters.'
     echo 'Enable or Disable Broadcom Wl?'
     OPTION=$(ugum choose Enable Disable)

--- a/build/ublue-os-just/50-akmods.just
+++ b/build/ublue-os-just/50-akmods.just
@@ -1,6 +1,7 @@
 # vim: set ft=make :
 
 alias gamepads := configure-gamepads
+
 # Configure gamepad drivers
 configure-gamepads ARG="prompt":
     #!/usr/bin/env bash
@@ -34,6 +35,7 @@ configure-gamepads ARG="prompt":
     fi
 
 alias broadcom-wl := configure-broadcom-wl
+
 # Configure Broadcom WL driver (Enabling WL breaks numerous other Wi-Fi adapters)
 configure-broadcom-wl ARG="prompt":
     #!/usr/bin/env bash

--- a/build/ublue-os-just/50-akmods.just
+++ b/build/ublue-os-just/50-akmods.just
@@ -1,39 +1,61 @@
 # vim: set ft=make :
 
 # Configure gamepad drivers
-configure-gamepads:
+configure-gamepads ARG="prompt":
     #!/usr/bin/env bash
     bold=$(tput bold)
     normal=$(tput sgr0)
-    echo "${bold}Configuring gamepad drivers${normal}"
-    echo 'Which drivers do you want to use?'
-    echo 'Note: Enabling xone and xpadneo can break some 3rd party controllers'
-    OPTION=$(ugum choose "Default Fedora drivers" "Enable xone and xpadneo" )
-    if [ "$OPTION" == "Enable xone and xpadneo" ]; then
+    OPTION={{ARG}}
+    if [ "$OPTION" == "prompt" ]; then
+      echo "${bold}Configuring gamepad drivers${normal}"
+      echo 'Which drivers do you want to use?'
+      echo 'Note: Enabling xone and xpadneo can break some 3rd party controllers'
+      OPTION=$(ugum choose "Default Fedora drivers" "Enable xone and xpadneo")
+    elif [ "$OPTION" == "help" ]; then
+      echo "Usage: ujust configure-gamepads <option>"
+      echo "  <option>: Specify the quick option - 'stock' or 'ublue'"
+      echo "  Use 'stock' to select Default Fedora Drivers"
+      echo "  Use 'ublue' to select Enable xone and xpadneo"
+      exit 0
+    fi
+    if [ "$OPTION" == "Enable xone and xpadneo" ] || [ "$OPTION" == "ublue" ]; then
       sudo rm -f /etc/modprobe.d/xone.conf
       sudo rm -f /etc/modprobe.d/xpadneo.conf
       sudo rm -f /etc/modprobe.d/xpad-noone-blacklist.conf
       sudo rm -f /etc/modules-load.d/xpad-noone.conf
-    elif [ "$OPTION" == "Default Fedora drivers" ]; then
+      echo "${bold}Enabled${normal} xone and xpadneo, please reboot for changes to take effect"
+    elif [ "$OPTION" == "Default Fedora drivers" ] || [ "$OPTION" == "stock" ]; then
       sudo bash -c '> /etc/modprobe.d/xone.conf'
       sudo bash -c '> /etc/modprobe.d/xpadneo.conf'
       sudo bash -c '> /etc/modprobe.d/xpad-noone-blacklist.conf'
       sudo bash -c '> /etc/modules-load.d/xpad-noone.conf'
+      echo "${bold}Disabled${normal} xone and xpadneo, please reboot for changes to take effect"
     fi
 
 # Configure Broadcom WL driver (Enabling WL breaks numerous other Wi-Fi adapters)
-configure-broadcom-wl:
+configure-broadcom-wl ARG="prompt":
     #!/usr/bin/env bash
     bold=$(tput bold)
     normal=$(tput sgr0)
-    echo "${bold}Configuring Broadcom Wi-Fi${normal}"
-    echo 'Enabling Broadcom WL driver will break numerous other Wi-Fi adapters.'
-    echo 'Enable or Disable Broadcom Wl?'
-    OPTION=$(ugum choose Enable Disable)
-    if [ "$OPTION" == "Enable" ]; then
+    OPTION={{ARG}}
+    if [ "$OPTION" == "prompt" ]; then
+      echo "${bold}Configuring Broadcom Wi-Fi${normal}"
+      echo 'Enabling Broadcom WL driver will break numerous other Wi-Fi adapters.'
+      echo 'Enable or Disable Broadcom Wl?'
+      OPTION=$(ugum choose Enable Disable)
+    elif [ "$OPTION" == "help" ]; then
+      echo "Usage: ujust configure-broadcom-wl <option>"
+      echo "  <option>: Specify the quick option - 'enable' or 'disable'"
+      echo "  Use 'enable' to select Enable"
+      echo "  Use 'disable' to select Disable"
+      exit 0
+    fi
+    if [ "${OPTION,,}" == "enable" ]; then
       sudo rm -f /etc/modprobe.d/broadcom-wl-blacklist.conf
       sudo rm -f /etc/modprobe.d/default-disable-broadcom-wl.conf
-    elif [ "$OPTION" == "Disable" ]; then
+      echo "${bold}Enabled${normal} Broadcom Wireless, please reboot for changes to take effect"
+    elif [ "${OPTION,,}" == "disable" ]; then
       sudo bash -c '> /etc/modules-load.d/broadcom-wl-blacklist.conf'
       sudo bash -c 'echo "blacklist wl" > /etc/modules-load.d/default-disable-broadcom-wl.conf'
+      echo "${bold}Disabled${normal} Broadcom Wireless, please reboot for changes to take effect"
     fi

--- a/build/ublue-os-just/50-akmods.just
+++ b/build/ublue-os-just/50-akmods.just
@@ -1,5 +1,6 @@
 # vim: set ft=make :
 
+alias gamepads := configure-gamepads
 # Configure gamepad drivers
 configure-gamepads ARG="prompt":
     #!/usr/bin/env bash
@@ -32,6 +33,7 @@ configure-gamepads ARG="prompt":
       echo "${bold}Disabled${normal} xone and xpadneo, please reboot for changes to take effect"
     fi
 
+alias broadcom-wl := configure-broadcom-wl
 # Configure Broadcom WL driver (Enabling WL breaks numerous other Wi-Fi adapters)
 configure-broadcom-wl ARG="prompt":
     #!/usr/bin/env bash

--- a/build/ublue-os-just/50-akmods.just
+++ b/build/ublue-os-just/50-akmods.just
@@ -5,7 +5,7 @@ configure-gamepads ARG="prompt":
     #!/usr/bin/env bash
     bold=$(tput bold)
     normal=$(tput sgr0)
-    OPTION={{ARG}}
+    OPTION={{ ARG }}
     if [ "$OPTION" == "prompt" ]; then
       echo "${bold}Configuring gamepad drivers${normal}"
       echo 'Which drivers do you want to use?'
@@ -37,7 +37,7 @@ configure-broadcom-wl ARG="prompt":
     #!/usr/bin/env bash
     bold=$(tput bold)
     normal=$(tput sgr0)
-    OPTION={{ARG}}
+    OPTION={{ ARG }}
     if [ "$OPTION" == "prompt" ]; then
       echo "${bold}Configuring Broadcom Wi-Fi${normal}"
       echo 'Enabling Broadcom WL driver will break numerous other Wi-Fi adapters.'

--- a/build/ublue-os-just/50-akmods.just
+++ b/build/ublue-os-just/50-akmods.just
@@ -6,25 +6,19 @@ configure-gamepads:
     bold=$(tput bold)
     normal=$(tput sgr0)
     echo "${bold}Configuring gamepad drivers${normal}"
-    echo 'uBlue (default and good for official controllers):'
-    echo ' - xpad-noone (xpad without Xbox One support), xpadneo, xone'
-    echo 'Stock:'
-    echo ' - Xbox one support and fixes a lot of third party controllers'
-    echo 'Which driver do you want to use?'
-    OPTION=$(ugum choose uBlue Stock)
-    if [ "$OPTION" == "uBlue" ]; then
+    echo 'Which drivers do you want to use?'
+    echo 'Note: Enabling xone and xpadneo can break some 3rd party controllers'
+    OPTION=$(ugum choose "Default Fedora drivers" "Enable xone and xpadneo" )
+    if [ "$OPTION" == "Enable xone and xpadneo" ]; then
       sudo rm -f /etc/modprobe.d/xone.conf
       sudo rm -f /etc/modprobe.d/xpadneo.conf
       sudo rm -f /etc/modprobe.d/xpad-noone-blacklist.conf
       sudo rm -f /etc/modules-load.d/xpad-noone.conf
-    elif [ "$OPTION" == "Stock" ]; then
+    elif [ "$OPTION" == "Default Fedora drivers" ]; then
       sudo bash -c '> /etc/modprobe.d/xone.conf'
       sudo bash -c '> /etc/modprobe.d/xpadneo.conf'
       sudo bash -c '> /etc/modprobe.d/xpad-noone-blacklist.conf'
       sudo bash -c '> /etc/modules-load.d/xpad-noone.conf'
-    else
-      echo 'Exiting...'
-      exit 0
     fi
 
 # Configure Broadcom WL driver (Enabling WL breaks numerous other Wi-Fi adapters)
@@ -39,7 +33,4 @@ configure-broadcom-wl:
     elif [ "$OPTION" == "Disable" ]; then
       sudo bash -c '> /etc/modules-load.d/broadcom-wl-blacklist.conf'
       sudo bash -c 'echo "blacklist wl" > /etc/modules-load.d/default-disable-broadcom-wl.conf'
-    else
-      echo 'Exiting...'
-      exit 0
     fi

--- a/build/ublue-os-just/50-akmods.just
+++ b/build/ublue-os-just/50-akmods.just
@@ -3,11 +3,14 @@
 # Configure gamepad drivers
 configure-gamepads:
     #!/usr/bin/env bash
-    echo 'Which driver do you want to use?'
+    bold=$(tput bold)
+    normal=$(tput sgr0)
+    echo "${bold}Configuring gamepad drivers${normal}"
     echo 'uBlue (default and good for official controllers):'
-    echo '  xpad (with no xbox one support), xpadneo, xone'
+    echo ' - xpad-noone (xpad without Xbox One support), xpadneo, xone'
     echo 'Stock:'
-    echo '  Xbox one support and fixes a lot of third party controllers'
+    echo ' - Xbox one support and fixes a lot of third party controllers'
+    echo 'Which driver do you want to use?'
     OPTION=$(ugum choose uBlue Stock)
     if [ "$OPTION" == "uBlue" ]; then
       sudo rm -f /etc/modprobe.d/xone.conf

--- a/build/ublue-os-just/50-akmods.just
+++ b/build/ublue-os-just/50-akmods.just
@@ -40,4 +40,3 @@ configure-broadcom-wl:
       echo 'Exiting...'
       exit 0
     fi
-    

--- a/build/ublue-os-just/50-akmods.just
+++ b/build/ublue-os-just/50-akmods.just
@@ -3,11 +3,11 @@
 alias gamepads := configure-gamepads
 
 # Configure gamepad drivers
-configure-gamepads ARG="prompt":
+configure-gamepads ACTION="prompt":
     #!/usr/bin/bash
     bold=$(tput bold)
     normal=$(tput sgr0)
-    OPTION={{ ARG }}
+    OPTION={{ ACTION }}
     if [ "$OPTION" == "prompt" ]; then
       echo "${bold}Configuring gamepad drivers${normal}"
       echo 'Which drivers do you want to use?'
@@ -37,11 +37,11 @@ configure-gamepads ARG="prompt":
 alias broadcom-wl := configure-broadcom-wl
 
 # Configure Broadcom WL driver (Enabling WL breaks numerous other Wi-Fi adapters)
-configure-broadcom-wl ARG="prompt":
+configure-broadcom-wl ACTION="prompt":
     #!/usr/bin/bash
     bold=$(tput bold)
     normal=$(tput sgr0)
-    OPTION={{ ARG }}
+    OPTION={{ ACTION }}
     if [ "$OPTION" == "prompt" ]; then
       echo "${bold}Configuring Broadcom Wi-Fi${normal}"
       echo 'Enabling Broadcom WL driver will break numerous other Wi-Fi adapters.'

--- a/build/ublue-os-just/60-custom.just
+++ b/build/ublue-os-just/60-custom.just
@@ -1,5 +1,5 @@
 # vim: set ft=make :
 
 # Enable xwaylandvideobridge
-fixscreenshare:
+fix-screenshare:
     cp /usr/share/applications/org.kde.xwaylandvideobridge.desktop $HOME/.config/autostart/

--- a/build/ublue-os-just/70-nix.just
+++ b/build/ublue-os-just/70-nix.just
@@ -4,7 +4,7 @@ alias nix := setup-nix
 
 # Install, uninstall or configure nix
 setup-nix ARG="prompt":
-    #!/usr/bin/env bash
+    #!/usr/bin/bash
     CURRENT_STATE="Not Installed"
     if [ -f "/etc/systemd/system/nix-daemon.socket" ]; then
       CURRENT_STATE="Installed"
@@ -72,7 +72,7 @@ alias fleek := setup-fleek
 
 # Install, uninstall or configure Fleek (https://getfleek.dev/)
 setup-fleek ARG="prompt":
-    #!/usr/bin/env bash
+    #!/usr/bin/bash
     if [ ! -f "/etc/systemd/system/nix-daemon.socket" ]; then
       echo "Please install nix first by running ujust setup-nix"
       exit 0
@@ -117,7 +117,7 @@ alias devbox := setup-devbox
 
 # Install or uninstall devbox
 setup-devbox ARG="prompt":
-    #!/usr/bin/env bash
+    #!/usr/bin/bash
     if [ ! -f "/etc/systemd/system/nix-daemon.socket" ]; then
       echo "Please install nix first by running ujust setup-nix"
       exit 0
@@ -152,7 +152,7 @@ setup-devbox ARG="prompt":
 
 # Installs nixGL
 install-nixgl:
-    #!/usr/bin/env bash
+    #!/usr/bin/bash
     if [ ! -f "/etc/systemd/system/nix-daemon.socket" ]; then
       echo "Please install nix first by running ujust setup-nix"
       exit 0

--- a/build/ublue-os-just/70-nix.just
+++ b/build/ublue-os-just/70-nix.just
@@ -18,32 +18,26 @@ setup-nix:
         "Add nix path to sudo" \
         "Remove nix path from sudo" \
       )
-    
     if [ "$OPTION" == "Install" ]; then
       curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sudo bash -s -- install --no-confirm
       sudo rm -f /etc/systemd/system/nix-daemon.service
       sudo rm -f /etc/systemd/system/nix-daemon.socket
       sudo cp /nix/var/nix/profiles/default/lib/systemd/system/nix-daemon.service /etc/systemd/system/nix-daemon.service
       sudo cp /nix/var/nix/profiles/default/lib/systemd/system/nix-daemon.socket /etc/systemd/system/nix-daemon.socket
-    
     elif [ "$OPTION" == "Uninstall" ]; then
       sudo /nix/nix-installer uninstall
       sudo rm -f /etc/systemd/system/nix-daemon.service
       sudo rm -f /etc/systemd/system/nix-daemon.socket
-
     elif [ "$OPTION" == "Update nix user profile" ]; then
       nix profile upgrade '.*'
-
     elif [ "$OPTION" == "Update all nix profiles" ]; then
       nix profile upgrade '.*'
       sudo nix profile upgrade '.*'
-
     elif [ "$OPTION" == "Re-copy nix systemd units to system" ]; then
       sudo rm -f /etc/systemd/system/nix-daemon.service
       sudo rm -f /etc/systemd/system/nix-daemon.socket
       sudo cp /nix/var/nix/profiles/default/lib/systemd/system/nix-daemon.service /etc/systemd/system/nix-daemon.service
       sudo cp /nix/var/nix/profiles/default/lib/systemd/system/nix-daemon.socket /etc/systemd/system/nix-daemon.socket
-    
     elif [ "$OPTION" == "Add nix path to sudo" ]; then
       sudo echo "Adding sudo path variables for nix"
       sudo rm -f /etc/sudoers.d/nix-sudo-env
@@ -52,13 +46,8 @@ setup-nix:
       Defaults  secure_path = /nix/var/nix/profiles/default/bin:/nix/var/nix/profiles/default/sbin:$SUDOPATHVARIABLE5
     EOF
       sudo echo "Finished adding sudo variables for nix"
-    
     elif [ "$OPTION" == "Remove nix path from sudo" ]; then
       sudo rm -f /etc/sudoers.d/nix-sudo-env
-    
-    else
-      echo 'Exiting...'
-      exit 0
     fi
 
 # Install, uninstall or configure Fleek (https://getfleek.dev/)
@@ -70,19 +59,16 @@ setup-fleek:
     fi
     echo 'What would you like to do with Fleek?'
     OPTION=$(ugum choose "Install Fleek" "Uninstall Fleek" "Integrate Nix/Fleek applications with system theme")
-    
     if [ "$OPTION" == "Install Fleek" ]; then
       mkdir -p $HOME/.config/nix
       echo "experimental-features = nix-command flakes" >> $HOME/.config/nix/nix.conf
       curl -fsSL https://getfleek.dev/installer | env FORCE=1 bash
-    
     elif [ "$OPTION" == "Uninstall Fleek" ]; then
       if [[ -x "/var/usrlocal/bin/fleek" ]]; then
         sudo rm -f /var/usrlocal/bin/fleek
       else
         echo "Fleek is not installed or has been already removed"
       fi
-    
     elif [ "$OPTION" == "Integrate Nix/Fleek applications with system theme" ]; then
       if [[ -x "/var/usrlocal/bin/fleek" ]]; then
         if command -v mutter; then
@@ -111,10 +97,8 @@ setup-devbox:
     echo "Devbox is currently: ${CURRENT_STATE}"
     echo 'What would you like to do with devbox?'
     OPTION=$(ugum choose Install Uninstall)
-    
     if [ "$OPTION" == "Install" ]; then
       curl -fsSL https://get.jetpack.io/devbox | bash
-    
     elif [ "$OPTION" == "Uninstall" ]; then
       if [[ -x "/var/usrlocal/bin/devbox" ]]; then
         sudo rm -f /var/usrlocal/bin/devbox

--- a/build/ublue-os-just/70-nix.just
+++ b/build/ublue-os-just/70-nix.just
@@ -1,6 +1,7 @@
 # vim: set ft=make :
 
 alias nix := setup-nix
+
 # Install, uninstall or configure nix
 setup-nix ARG="prompt":
     #!/usr/bin/env bash
@@ -68,6 +69,7 @@ setup-nix ARG="prompt":
     fi
 
 alias fleek := setup-fleek
+
 # Install, uninstall or configure Fleek (https://getfleek.dev/)
 setup-fleek ARG="prompt":
     #!/usr/bin/env bash
@@ -112,6 +114,7 @@ setup-fleek ARG="prompt":
     fi
 
 alias devbox := setup-devbox
+
 # Install or uninstall devbox
 setup-devbox ARG="prompt":
     #!/usr/bin/env bash

--- a/build/ublue-os-just/70-nix.just
+++ b/build/ublue-os-just/70-nix.just
@@ -1,119 +1,133 @@
 # vim: set ft=make :
 
-# Install Nix with the Determinate Nix Installer
-nix-install:
+# Install, uninstall or configure nix
+setup-nix:
     #!/usr/bin/env bash
-    curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sudo bash -s -- install --no-confirm
-    sudo rm -f /etc/systemd/system/nix-daemon.service
-    sudo rm -f /etc/systemd/system/nix-daemon.socket
-    sudo cp /nix/var/nix/profiles/default/lib/systemd/system/nix-daemon.service /etc/systemd/system/nix-daemon.service
-    sudo cp /nix/var/nix/profiles/default/lib/systemd/system/nix-daemon.socket /etc/systemd/system/nix-daemon.socket
+    CURRENT_STATE="Not Installed"
+    if [ -f "/etc/systemd/system/nix-daemon.socket" ]; then
+      CURRENT_STATE="Installed"
+    fi
+    echo "Nix is currently: ${CURRENT_STATE}"
+    echo 'What would you like to do with Nix?'
+    OPTION=$(ugum choose \
+        Install \
+        Uninstall \
+        "Update nix user profile" \
+        "Update all nix profiles" \
+        "Re-copy nix systemd units to system" \
+        "Add nix path to sudo" \
+        "Remove nix path from sudo" \
+      )
+    
+    if [ "$OPTION" == "Install" ]; then
+      curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sudo bash -s -- install --no-confirm
+      sudo rm -f /etc/systemd/system/nix-daemon.service
+      sudo rm -f /etc/systemd/system/nix-daemon.socket
+      sudo cp /nix/var/nix/profiles/default/lib/systemd/system/nix-daemon.service /etc/systemd/system/nix-daemon.service
+      sudo cp /nix/var/nix/profiles/default/lib/systemd/system/nix-daemon.socket /etc/systemd/system/nix-daemon.socket
+    
+    elif [ "$OPTION" == "Uninstall" ]; then
+      sudo /nix/nix-installer uninstall
+      sudo rm -f /etc/systemd/system/nix-daemon.service
+      sudo rm -f /etc/systemd/system/nix-daemon.socket
 
-# Uninstall Nix
-nix-remove:
-    sudo /nix/nix-installer uninstall
-    sudo rm -f /etc/systemd/system/nix-daemon.service
-    sudo rm -f /etc/systemd/system/nix-daemon.socket
+    elif [ "$OPTION" == "Update nix user profile" ]; then
+      nix profile upgrade '.*'
 
-# Adds the nix bin path to the sudoers config
-nix-sudo:
-    #!/usr/bin/env bash
-    sudo echo "Adding sudo path variables for nix"
-    sudo rm -f /etc/sudoers.d/nix-sudo-env
-    SUDOPATHVARIABLE5=$(sudo printenv PATH)
-    sudo tee /etc/sudoers.d/nix-sudo-env <<EOF
-    Defaults  secure_path = /nix/var/nix/profiles/default/bin:/nix/var/nix/profiles/default/sbin:$SUDOPATHVARIABLE5
+    elif [ "$OPTION" == "Update all nix profiles" ]; then
+      nix profile upgrade '.*'
+      sudo nix profile upgrade '.*'
+
+    elif [ "$OPTION" == "Re-copy nix systemd units to system" ]; then
+      sudo rm -f /etc/systemd/system/nix-daemon.service
+      sudo rm -f /etc/systemd/system/nix-daemon.socket
+      sudo cp /nix/var/nix/profiles/default/lib/systemd/system/nix-daemon.service /etc/systemd/system/nix-daemon.service
+      sudo cp /nix/var/nix/profiles/default/lib/systemd/system/nix-daemon.socket /etc/systemd/system/nix-daemon.socket
+    
+    elif [ "$OPTION" == "Add nix path to sudo" ]; then
+      sudo echo "Adding sudo path variables for nix"
+      sudo rm -f /etc/sudoers.d/nix-sudo-env
+      SUDOPATHVARIABLE5=$(sudo printenv PATH)
+      sudo tee /etc/sudoers.d/nix-sudo-env <<EOF
+      Defaults  secure_path = /nix/var/nix/profiles/default/bin:/nix/var/nix/profiles/default/sbin:$SUDOPATHVARIABLE5
     EOF
-    sudo echo "Finished adding sudo variables for nix"
+      sudo echo "Finished adding sudo variables for nix"
+    
+    elif [ "$OPTION" == "Remove nix path from sudo" ]; then
+      sudo rm -f /etc/sudoers.d/nix-sudo-env
+    
+    else
+      echo 'Exiting...'
+      exit 0
+    fi
 
-# Removes nix bin path from sudoers config
-nix-sudo-undo:
-    sudo rm -f /etc/sudoers.d/nix-sudo-env
-
-# Install Fleek (https://getfleek.dev/)
-fleek-install:
+# Install, uninstall or configure Fleek (https://getfleek.dev/)
+setup-fleek:
     #!/usr/bin/env bash
-    if [[ -d "/nix" ]]; then
+    if [ ! -f "/etc/systemd/system/nix-daemon.socket" ]; then
+      echo "Please install nix first by running ujust setup-nix"
+      exit 0
+    fi
+    echo 'What would you like to do with Fleek?'
+    OPTION=$(ugum choose "Install Fleek" "Uninstall Fleek" "Integrate Nix/Fleek applications with system theme")
+    
+    if [ "$OPTION" == "Install Fleek" ]; then
       mkdir -p $HOME/.config/nix
       echo "experimental-features = nix-command flakes" >> $HOME/.config/nix/nix.conf
       curl -fsSL https://getfleek.dev/installer | env FORCE=1 bash
-    else
-      echo "Install nix with ujust nix-install before running ujust fleek-install."
-    fi
-
-# Removes Fleek
-fleek-remove:
-    #!/usr/bin/env bash
-    if [[ -x "/var/usrlocal/bin/fleek" ]]; then
-      sudo rm -f /var/usrlocal/bin/fleek
-    else
-      echo "Fleek is not installed or has been already removed"
-    fi
-
-# Integrate Nix/Fleek applications with system theme
-fleek-themes-install:
-    #!/usr/bin/env bash
-    if [[ -x "/var/usrlocal/bin/fleek" ]]; then
-      if command -v mutter; then
-        fleek add adw-gtk3 --apply
+    
+    elif [ "$OPTION" == "Uninstall Fleek" ]; then
+      if [[ -x "/var/usrlocal/bin/fleek" ]]; then
+        sudo rm -f /var/usrlocal/bin/fleek
       else
-        fleek add breeze-icons
-        fleek add libsForQt5.breeze-qt5
-        fleek apply
+        echo "Fleek is not installed or has been already removed"
       fi
-    else
-      echo "Install fleek with ujust fleek-install before running ujust fleek-themes-install."
+    
+    elif [ "$OPTION" == "Integrate Nix/Fleek applications with system theme" ]; then
+      if [[ -x "/var/usrlocal/bin/fleek" ]]; then
+        if command -v mutter; then
+          fleek add adw-gtk3 --apply
+        else
+          fleek add breeze-icons
+          fleek add libsForQt5.breeze-qt5
+          fleek apply
+        fi
+      else
+        echo "Install fleek with ujust fleek-install before running ujust fleek-themes-install."
+      fi
     fi
 
-# Installs Devbox
-devbox-install:
+# Install or uninstall devbox
+setup-devbox:
     #!/usr/bin/env bash
-    if [[ -d "/nix" ]]; then
+    if [ ! -f "/etc/systemd/system/nix-daemon.socket" ]; then
+      echo "Please install nix first by running ujust setup-nix"
+      exit 0
+    fi
+    CURRENT_STATE="Not Installed"
+    if [ -f "/var/usrlocal/bin/devbox" ]; then
+      CURRENT_STATE="Installed"
+    fi
+    echo "Devbox is currently: ${CURRENT_STATE}"
+    echo 'What would you like to do with devbox?'
+    OPTION=$(ugum choose Install Uninstall)
+    
+    if [ "$OPTION" == "Install" ]; then
       curl -fsSL https://get.jetpack.io/devbox | bash
-    else
-      echo "Install nix with ujust nix-install before running ujust devbox-install."
-    fi
-
-# Removes Devbox
-devbox-remove:
-    #!/usr/bin/env bash
-    if [[ -x "/var/usrlocal/bin/devbox" ]]; then
-      sudo rm -f /var/usrlocal/bin/devbox
-    else
-      echo "Devbox is not installed or has been already removed"
+    
+    elif [ "$OPTION" == "Uninstall" ]; then
+      if [[ -x "/var/usrlocal/bin/devbox" ]]; then
+        sudo rm -f /var/usrlocal/bin/devbox
+      else
+        echo "Devbox is not installed or has been already removed"
+      fi
     fi
 
 # Installs nixGL
-nixgl-install:
+install-nixgl:
     #!/usr/bin/env bash
-    if [[ -d "/nix" ]]; then
-      nix profile install github:guibou/nixGL --impure
-    else
-      echo "NixGL requires nix to install."
+    if [ ! -f "/etc/systemd/system/nix-daemon.socket" ]; then
+      echo "Please install nix first by running ujust setup-nix"
+      exit 0
     fi
-
-# Upgrades user nix profile
-nix-update-user:
-    #!/usr/bin/env bash
-    if [[ -d "/nix" ]]; then
-      nix profile upgrade '.*'
-    else
-      echo "Nix is not installed"
-    fi
-
-# Upgrades both user and root nix profiles
-nix-update-all:
-    #!/usr/bin/env bash
-    if [[ -d "/nix" ]]; then
-      nix profile upgrade '.*'
-      sudo nix profile upgrade '.*'
-    else
-      echo "Nix is not installed"
-    fi
-
-# Deletes and recoppies nix systemd units to ensure that they are the same
-nix-systemd-copy:
-    sudo rm -f /etc/systemd/system/nix-daemon.service
-    sudo rm -f /etc/systemd/system/nix-daemon.socket
-    sudo cp /nix/var/nix/profiles/default/lib/systemd/system/nix-daemon.service /etc/systemd/system/nix-daemon.service
-    sudo cp /nix/var/nix/profiles/default/lib/systemd/system/nix-daemon.socket /etc/systemd/system/nix-daemon.socket
+    nix profile install github:guibou/nixGL --impure

--- a/build/ublue-os-just/70-nix.just
+++ b/build/ublue-os-just/70-nix.just
@@ -1,5 +1,6 @@
 # vim: set ft=make :
 
+alias nix := setup-nix
 # Install, uninstall or configure nix
 setup-nix ARG="prompt":
     #!/usr/bin/env bash
@@ -66,6 +67,7 @@ setup-nix ARG="prompt":
       sudo rm -f /etc/sudoers.d/nix-sudo-env
     fi
 
+alias fleek := setup-fleek
 # Install, uninstall or configure Fleek (https://getfleek.dev/)
 setup-fleek ARG="prompt":
     #!/usr/bin/env bash
@@ -109,6 +111,7 @@ setup-fleek ARG="prompt":
       fi
     fi
 
+alias devbox := setup-devbox
 # Install or uninstall devbox
 setup-devbox ARG="prompt":
     #!/usr/bin/env bash

--- a/build/ublue-os-just/70-nix.just
+++ b/build/ublue-os-just/70-nix.just
@@ -53,25 +53,35 @@ setup-nix:
     fi
 
 # Install, uninstall or configure Fleek (https://getfleek.dev/)
-setup-fleek:
+setup-fleek ARG="prompt":
     #!/usr/bin/env bash
     if [ ! -f "/etc/systemd/system/nix-daemon.socket" ]; then
       echo "Please install nix first by running ujust setup-nix"
       exit 0
     fi
-    echo 'What would you like to do with Fleek?'
-    OPTION=$(ugum choose "Install Fleek" "Uninstall Fleek" "Integrate Nix/Fleek applications with system theme")
-    if [ "$OPTION" == "Install Fleek" ]; then
+    OPTION={{ARG}}
+    if [ "$OPTION" == "prompt" ]; then
+      echo 'What would you like to do with Fleek?'
+      OPTION=$(ugum choose "Install Fleek" "Uninstall Fleek" "Integrate Nix/Fleek applications with system theme")
+    elif [ "$OPTION" == "help" ]; then
+      echo "Usage: ujust setup-fleek <option>"
+      echo "  <option>: Specify the quick option - 'install', 'remove', or 'integrate'"
+      echo "  Use 'install' to select install"
+      echo "  Use 'remove' to select uninstall"
+      echo "  Use 'integrate' to integrate nix applications with system theme."
+      exit 0
+    fi
+    if [ "$OPTION" == "Install Fleek" ] || [ "${OPTION,,} == "install" ]; then
       mkdir -p $HOME/.config/nix
       echo "experimental-features = nix-command flakes" >> $HOME/.config/nix/nix.conf
       curl -fsSL https://getfleek.dev/installer | env FORCE=1 bash
-    elif [ "$OPTION" == "Uninstall Fleek" ]; then
+    elif [ "$OPTION" == "Uninstall Fleek" ] || [ "${OPTION,,} == "remove" ]; then
       if [[ -x "/var/usrlocal/bin/fleek" ]]; then
         sudo rm -f /var/usrlocal/bin/fleek
       else
         echo "Fleek is not installed or has been already removed"
       fi
-    elif [ "$OPTION" == "Integrate Nix/Fleek applications with system theme" ]; then
+    elif [ "$OPTION" == "Integrate Nix/Fleek applications with system theme" ] || [ "${OPTION,,} == "integrate" ]; then
       if [[ -x "/var/usrlocal/bin/fleek" ]]; then
         if command -v mutter; then
           fleek add adw-gtk3 --apply
@@ -86,7 +96,7 @@ setup-fleek:
     fi
 
 # Install or uninstall devbox
-setup-devbox:
+setup-devbox ARG="prompt":
     #!/usr/bin/env bash
     if [ ! -f "/etc/systemd/system/nix-daemon.socket" ]; then
       echo "Please install nix first by running ujust setup-nix"
@@ -98,12 +108,21 @@ setup-devbox:
     fi
     bold=$(tput bold)
     normal=$(tput sgr0)
-    echo "Devbox is currently: ${bold}${CURRENT_STATE}${normal}"
-    echo 'What would you like to do with devbox?'
-    OPTION=$(ugum choose Install Uninstall)
-    if [ "$OPTION" == "Install" ]; then
+    OPTION={{ARG}}
+    if [ "$OPTION" == "prompt" ]; then
+      echo "Devbox is currently: ${bold}${CURRENT_STATE}${normal}"
+      echo 'What would you like to do with devbox?'
+      OPTION=$(ugum choose Install Uninstall)
+    elif [ "$OPTION" == "help" ]; then
+      echo "Usage: ujust toggle-updates <option>"
+      echo "  <option>: Specify the quick option - 'install' or 'remove'"
+      echo "  Use 'install' to Install devbox"
+      echo "  Use 'remove' to Remove devbox."
+      exit 0
+    fi
+    if [ "${OPTION,,}" == "Install" ]; then
       curl -fsSL https://get.jetpack.io/devbox | bash
-    elif [ "$OPTION" == "Uninstall" ]; then
+    elif [ "${OPTION,,}" == "Uninstall" ] || [ "${OPTION,,}" == "remove" ]; then
       if [[ -x "/var/usrlocal/bin/devbox" ]]; then
         sudo rm -f /var/usrlocal/bin/devbox
       else

--- a/build/ublue-os-just/70-nix.just
+++ b/build/ublue-os-just/70-nix.just
@@ -7,7 +7,9 @@ setup-nix:
     if [ -f "/etc/systemd/system/nix-daemon.socket" ]; then
       CURRENT_STATE="Installed"
     fi
-    echo "Nix is currently: ${CURRENT_STATE}"
+    bold=$(tput bold)
+    normal=$(tput sgr0)
+    echo "Nix is currently: ${bold}${CURRENT_STATE}${normal}"
     echo 'What would you like to do with Nix?'
     OPTION=$(ugum choose \
         Install \
@@ -94,7 +96,9 @@ setup-devbox:
     if [ -f "/var/usrlocal/bin/devbox" ]; then
       CURRENT_STATE="Installed"
     fi
-    echo "Devbox is currently: ${CURRENT_STATE}"
+    bold=$(tput bold)
+    normal=$(tput sgr0)
+    echo "Devbox is currently: ${bold}${CURRENT_STATE}${normal}"
     echo 'What would you like to do with devbox?'
     OPTION=$(ugum choose Install Uninstall)
     if [ "$OPTION" == "Install" ]; then

--- a/build/ublue-os-just/70-nix.just
+++ b/build/ublue-os-just/70-nix.just
@@ -1,7 +1,7 @@
 # vim: set ft=make :
 
 # Install, uninstall or configure nix
-setup-nix:
+setup-nix ARG="prompt":
     #!/usr/bin/env bash
     CURRENT_STATE="Not Installed"
     if [ -f "/etc/systemd/system/nix-daemon.socket" ]; then
@@ -9,38 +9,52 @@ setup-nix:
     fi
     bold=$(tput bold)
     normal=$(tput sgr0)
-    echo "Nix is currently: ${bold}${CURRENT_STATE}${normal}"
-    echo 'What would you like to do with Nix?'
-    OPTION=$(ugum choose \
-        Install \
-        Uninstall \
-        "Update nix user profile" \
-        "Update all nix profiles" \
-        "Re-copy nix systemd units to system" \
-        "Add nix path to sudo" \
-        "Remove nix path from sudo" \
-      )
-    if [ "$OPTION" == "Install" ]; then
+    OPTION={{ ARG }}
+    if [ "$OPTION" == "prompt" ]; then
+      echo "Nix is currently: ${bold}${CURRENT_STATE}${normal}"
+      echo 'What would you like to do with Nix?'
+      OPTION=$(ugum choose \
+          Install \
+          Uninstall \
+          "Update nix user profile" \
+          "Update all nix profiles" \
+          "Re-copy nix systemd units to system" \
+          "Add nix path to sudo" \
+          "Remove nix path from sudo" \
+        )
+    elif [ "$OPTION" == "help" ]; then
+      echo "Usage: ujust setup-nix <option>"
+      echo "  <option>: Specify the quick option - 'install', 'remove', etc"
+      echo "  Use 'install' to select Install nix"
+      echo "  Use 'remove' to select Uninstall nix"
+      echo "  Use 'upgrade' to Upgrade nix user profile"
+      echo "  Use 'upgrade-all' to Upgrade all nix profiles"
+      echo "  Use 'recopy' to Re-copy nix systemd units to system"
+      echo "  Use 'sudo' to Add nix path to sudo"
+      echo "  Use 'remove-sudo' to Remove nix path from sudo."
+      exit 0
+    fi
+    if [ "${OPTION,,}" == "Install" ]; then
       curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sudo bash -s -- install --no-confirm
       sudo rm -f /etc/systemd/system/nix-daemon.service
       sudo rm -f /etc/systemd/system/nix-daemon.socket
       sudo cp /nix/var/nix/profiles/default/lib/systemd/system/nix-daemon.service /etc/systemd/system/nix-daemon.service
       sudo cp /nix/var/nix/profiles/default/lib/systemd/system/nix-daemon.socket /etc/systemd/system/nix-daemon.socket
-    elif [ "$OPTION" == "Uninstall" ]; then
+    elif [ "${OPTION,,}" == "Uninstall" ] || [ "${OPTION,,}" == "remove" ]; then
       sudo /nix/nix-installer uninstall
       sudo rm -f /etc/systemd/system/nix-daemon.service
       sudo rm -f /etc/systemd/system/nix-daemon.socket
-    elif [ "$OPTION" == "Update nix user profile" ]; then
+    elif [ "$OPTION" == "Update nix user profile" ] || [ "${OPTION,,}" == "upgrade" ]; then
       nix profile upgrade '.*'
-    elif [ "$OPTION" == "Update all nix profiles" ]; then
+    elif [ "$OPTION" == "Update all nix profiles" ] || [ "${OPTION,,}" == "upgrade-all" ]; then
       nix profile upgrade '.*'
       sudo nix profile upgrade '.*'
-    elif [ "$OPTION" == "Re-copy nix systemd units to system" ]; then
+    elif [ "$OPTION" == "Re-copy nix systemd units to system" ] || [ "${OPTION,,}" == "recopy" ]; then
       sudo rm -f /etc/systemd/system/nix-daemon.service
       sudo rm -f /etc/systemd/system/nix-daemon.socket
       sudo cp /nix/var/nix/profiles/default/lib/systemd/system/nix-daemon.service /etc/systemd/system/nix-daemon.service
       sudo cp /nix/var/nix/profiles/default/lib/systemd/system/nix-daemon.socket /etc/systemd/system/nix-daemon.socket
-    elif [ "$OPTION" == "Add nix path to sudo" ]; then
+    elif [ "$OPTION" == "Add nix path to sudo" ] || [ "${OPTION,,}" == "sudo" ]; then
       sudo echo "Adding sudo path variables for nix"
       sudo rm -f /etc/sudoers.d/nix-sudo-env
       SUDOPATHVARIABLE5=$(sudo printenv PATH)
@@ -48,7 +62,7 @@ setup-nix:
       Defaults  secure_path = /nix/var/nix/profiles/default/bin:/nix/var/nix/profiles/default/sbin:$SUDOPATHVARIABLE5
     EOF
       sudo echo "Finished adding sudo variables for nix"
-    elif [ "$OPTION" == "Remove nix path from sudo" ]; then
+    elif [ "$OPTION" == "Remove nix path from sudo" ] || [ "${OPTION,,}" == "remove-sudo" ]; then
       sudo rm -f /etc/sudoers.d/nix-sudo-env
     fi
 

--- a/build/ublue-os-just/70-nix.just
+++ b/build/ublue-os-just/70-nix.just
@@ -3,7 +3,7 @@
 alias nix := setup-nix
 
 # Install, uninstall or configure nix
-setup-nix ARG="prompt":
+setup-nix ACTION="prompt":
     #!/usr/bin/bash
     CURRENT_STATE="Not Installed"
     if [ -f "/etc/systemd/system/nix-daemon.socket" ]; then
@@ -11,7 +11,7 @@ setup-nix ARG="prompt":
     fi
     bold=$(tput bold)
     normal=$(tput sgr0)
-    OPTION={{ ARG }}
+    OPTION={{ ACTION }}
     if [ "$OPTION" == "prompt" ]; then
       echo "Nix is currently: ${bold}${CURRENT_STATE}${normal}"
       echo 'What would you like to do with Nix?'
@@ -71,13 +71,13 @@ setup-nix ARG="prompt":
 alias fleek := setup-fleek
 
 # Install, uninstall or configure Fleek (https://getfleek.dev/)
-setup-fleek ARG="prompt":
+setup-fleek ACTION="prompt":
     #!/usr/bin/bash
     if [ ! -f "/etc/systemd/system/nix-daemon.socket" ]; then
       echo "Please install nix first by running ujust setup-nix"
       exit 0
     fi
-    OPTION={{ ARG }}
+    OPTION={{ ACTION }}
     if [ "$OPTION" == "prompt" ]; then
       echo 'What would you like to do with Fleek?'
       OPTION=$(ugum choose "Install Fleek" "Uninstall Fleek" "Integrate Nix/Fleek applications with system theme")
@@ -116,7 +116,7 @@ setup-fleek ARG="prompt":
 alias devbox := setup-devbox
 
 # Install or uninstall devbox
-setup-devbox ARG="prompt":
+setup-devbox ACTION="prompt":
     #!/usr/bin/bash
     if [ ! -f "/etc/systemd/system/nix-daemon.socket" ]; then
       echo "Please install nix first by running ujust setup-nix"
@@ -128,7 +128,7 @@ setup-devbox ARG="prompt":
     fi
     bold=$(tput bold)
     normal=$(tput sgr0)
-    OPTION={{ ARG }}
+    OPTION={{ ACTION }}
     if [ "$OPTION" == "prompt" ]; then
       echo "Devbox is currently: ${bold}${CURRENT_STATE}${normal}"
       echo 'What would you like to do with devbox?'

--- a/build/ublue-os-just/70-nix.just
+++ b/build/ublue-os-just/70-nix.just
@@ -59,7 +59,7 @@ setup-fleek ARG="prompt":
       echo "Please install nix first by running ujust setup-nix"
       exit 0
     fi
-    OPTION={{ARG}}
+    OPTION={{ ARG }}
     if [ "$OPTION" == "prompt" ]; then
       echo 'What would you like to do with Fleek?'
       OPTION=$(ugum choose "Install Fleek" "Uninstall Fleek" "Integrate Nix/Fleek applications with system theme")
@@ -108,7 +108,7 @@ setup-devbox ARG="prompt":
     fi
     bold=$(tput bold)
     normal=$(tput sgr0)
-    OPTION={{ARG}}
+    OPTION={{ ARG }}
     if [ "$OPTION" == "prompt" ]; then
       echo "Devbox is currently: ${bold}${CURRENT_STATE}${normal}"
       echo 'What would you like to do with devbox?'

--- a/build/ublue-os-just/70-nix.just
+++ b/build/ublue-os-just/70-nix.just
@@ -36,13 +36,13 @@ setup-nix ARG="prompt":
       echo "  Use 'remove-sudo' to Remove nix path from sudo."
       exit 0
     fi
-    if [ "${OPTION,,}" == "Install" ]; then
+    if [ "${OPTION,,}" == "install" ]; then
       curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sudo bash -s -- install --no-confirm
       sudo rm -f /etc/systemd/system/nix-daemon.service
       sudo rm -f /etc/systemd/system/nix-daemon.socket
       sudo cp /nix/var/nix/profiles/default/lib/systemd/system/nix-daemon.service /etc/systemd/system/nix-daemon.service
       sudo cp /nix/var/nix/profiles/default/lib/systemd/system/nix-daemon.socket /etc/systemd/system/nix-daemon.socket
-    elif [ "${OPTION,,}" == "Uninstall" ] || [ "${OPTION,,}" == "remove" ]; then
+    elif [ "${OPTION,,}" == "uninstall" ] || [ "${OPTION,,}" == "remove" ]; then
       sudo /nix/nix-installer uninstall
       sudo rm -f /etc/systemd/system/nix-daemon.service
       sudo rm -f /etc/systemd/system/nix-daemon.socket
@@ -140,9 +140,9 @@ setup-devbox ARG="prompt":
       echo "  Use 'remove' to Remove devbox."
       exit 0
     fi
-    if [ "${OPTION,,}" == "Install" ]; then
+    if [ "${OPTION,,}" == "install" ]; then
       curl -fsSL https://get.jetpack.io/devbox | bash
-    elif [ "${OPTION,,}" == "Uninstall" ] || [ "${OPTION,,}" == "remove" ]; then
+    elif [ "${OPTION,,}" == "uninstall" ] || [ "${OPTION,,}" == "remove" ]; then
       if [[ -x "/var/usrlocal/bin/devbox" ]]; then
         sudo rm -f /var/usrlocal/bin/devbox
       else


### PR DESCRIPTION
This patch, when complete will be the second step in addressing #148 now that we have `ugum` on all images which solved the need of a standardized way to select between options.

This is something that i will be chipping away at when i am able to.

Naming scheme for just recipes (draft) will be:
- `setup-` Used when the recipe provides a way to install and remove something (configuration can also be added here)
- `configure-` Used to configure something that is pre-installed on the ublue system (maybe shorten to `config-`?)
- `install-` Used by recipes where there is no functionality other than install
- `remove-` used by `remove-brew` due to the issues we got reported where it broke flatpak,  please ignore
- `toggle-` switch something on/off like for example `toggle-gnome-vrr` (if it makes sense maybe ditch `toggle-` and use `configure-` instead, unless we keep toggle for things that are specifically on/off switches?)
- `fix-` Apply a patch/workaround to something
- `thing` A single task that works as a shortcut and needs to be memorable, like `update` or `changelog`

Also i have added aliases to provide a shorter name for recipes too where i felt it was warranted.

Input about this proposed scheme is appreciated before merging

Snippet for choice dialogs (adjust for your needs)
```bash
#!/bin/bash
bold=$(tput bold)
normal=$(tput sgr0)
echo "${bold}Title${normal}"
echo 'text?'
OPTION=$(ugum choose option1 "option 2")
if [ "$OPTION" == "option1" ]; then
  echo 'stuff'
elif [ "$OPTION" == "option 2" ]; then
  echo 'other stuff'
fi
```

If you have a lot of options (more than 3?) you can do what i did for nix for readablilty
```bash
OPTION=$(ugum choose \
    option1 \
    "option 2" \
    "another option" \
    option4 \
  )
```
Using `ugum` (universal gum) will let it generate choice dialogs even when `gum` is not installed, they will look something like this:

With `gum` installed, gum will be prioritized:
![image](https://github.com/ublue-os/config/assets/2557889/f1bcf1c1-86b7-43f9-9bc7-d23a94a1d1c7)

Without `gum` but with `fzf` is installed, fallback to fzf:
![image](https://github.com/ublue-os/config/assets/2557889/4396b975-84bc-4f43-9305-c25b6a9c52bc)

Without both `fzf` and `gum`, fallback to pure bash:
![image](https://github.com/ublue-os/config/assets/2557889/3be7cc24-944c-4c36-abd8-c38c03fed144)
