### PR TITLE
feat(just): Generate tab completion for ujust

### DIFF
--- a/build/ublue-os-just/ublue-os-just.spec
+++ b/build/ublue-os-just/ublue-os-just.spec
@@ -59,7 +59,7 @@ install -Dm755 %{SOURCE10} %{buildroot}%{_bindir}/ugum
 
 %post
 # Generate ujust bash completion
-just --completion bash | perl -pe 's/([\(_" ])just/\1ujust/g' > %{_datadir}/bash-completion/completions/ujust
+just --completions bash | sed -E 's/([\(_" ])just/\1ujust/g' > %{_datadir}/bash-completion/completions/ujust
 chmod 644 %{_datadir}/bash-completion/completions/ujust 
 
 %changelog

--- a/build/ublue-os-just/ublue-os-just.spec
+++ b/build/ublue-os-just/ublue-os-just.spec
@@ -8,7 +8,7 @@ License:        MIT
 URL:            https://github.com/ublue-os/config
 
 BuildArch:      noarch
-Supplements:    just
+Requires:    just
 
 Source0:        ublue-os-just.sh
 Source1:        00-default.just
@@ -57,7 +57,15 @@ install -Dm755 %{SOURCE10} %{buildroot}%{_bindir}/ugum
 %attr(0755,root,root) %{_bindir}/ujust
 %attr(0755,root,root) %{_bindir}/ugum
 
+%post
+# Generate ujust bash completion
+just --completion bash | perl -pe 's/([\(_" ])just/\1ujust/g' > %{_datadir}/bash-completion/completions/ujust
+chmod 644 %{_datadir}/bash-completion/completions/ujust 
+
 %changelog
+* Wed Jan 10 2024 HikariKnight <2557889+HikariKnight@users.noreply.github.com> - 0.21
+- Added ujust tab completion file generated from just --completions bash
+
 * Thu Jan 04 2024 Kyle Gospodnetich <me@kylegospodneti.ch> - 0.20
 - Update with support for the newest version of just
 


### PR DESCRIPTION
Addresses #187 

Adds a postinstall step to the rpm spec file which will run
`just --completion bash | perl -pe 's/([\(_" ])just/\1ujust/g' > %{_datadir}/bash-completion/completions/ujust`

`just --completion bash` generates a just bash completion file and outputs it to STDOUT
`perl -pe 's/([\(_" ])just/\1ujust/g' > %{_datadir}/bash-completion/completions/ujust` rewrites the output using perl so that the bash completion will work for ujust and writes the output to an ujust bash completion file.

edit: replaced `perl -pe` with `sed -E` as we found out the regex worked in that and perl is not guaranteed to be on potential systems the rpm will be installed on