### PR TITLE
fix: change rpm-ostreed-automatic timer from 4AM local time to 4PM/16:00 UTC

### DIFF
--- a/files/usr/etc/systemd/system/rpm-ostreed-automatic.timer.d/override.conf
+++ b/files/usr/etc/systemd/system/rpm-ostreed-automatic.timer.d/override.conf
@@ -1,4 +1,4 @@
 [Timer]
 RandomizedDelaySec=10m
-OnCalendar=*-*-* 4:00:00
+OnCalendar=*-*-* 16:00:00 UTC
 Persistent=true


### PR DESCRIPTION
I think this makes slightly more sense than updating at 4AM/04:00 local time.
[Is this intentional or is this just a typo?](https://github.com/ublue-os/config/blob/3da21b60298c8b7a9a2ba745f134d7c2fd71e4b0/files/usr/etc/systemd/system/rpm-ostreed-automatic.timer.d/override.conf)

[The GitHub actions for main kick off at 3PM/15:00 UTC.](https://github.com/ublue-os/main/blob/cb54f2c85b07e6a51dcfc6e2fd38fd6eb6647de1/.github/workflows/build.yml)

Why not just check for updates as soon as they are available?
This would only benefit images that are finished building in GitHub before 4PM UTC.

Off the top of my head I can't think of any downsides compared to the current state.