### PR TITLE
feat: add more flexibility to user-motd

### DIFF
--- a/build/ublue-os-just/etc-profile.d/user-motd.sh
+++ b/build/ublue-os-just/etc-profile.d/user-motd.sh
@@ -1,7 +1,9 @@
 if test -d "$HOME"; then
   if test ! -e "$HOME"/.config/no-show-user-motd; then
-    if test -s "/usr/share/ublue-os/user-motd"; then
-      cat /usr/share/ublue-os/user-motd
+    if test -x "/usr/libexec/ublue-motd"; then
+      /usr/libexec/ublue-motd
+    elif test -s "/etc/user-motd"; then
+      cat /etc/user-motd
     fi
   fi
 fi

--- a/build/ublue-os-just/ublue-os-just.spec
+++ b/build/ublue-os-just/ublue-os-just.spec
@@ -1,7 +1,7 @@
 Name:           ublue-os-just
 Packager:       ublue-os
 Vendor:         ublue-os
-Version:        0.25
+Version:        0.26
 Release:        1%{?dist}
 Summary:        ublue-os just integration
 License:        MIT
@@ -89,6 +89,9 @@ just --completions bash | sed -E 's/([\(_" ])just/\1ujust/g' > %{_datadir}/bash-
 chmod 644 %{_datadir}/bash-completion/completions/ujust 
 
 %changelog
+* Sat Jan 29 2024 Benjamin Sherman <benjamin@holyarmy.org> - 0.26
+- Improve versatility of user-motd
+
 * Sat Jan 27 2024 Benjamin Sherman <benjamin@holyarmy.org> - 0.25
 - Add user-motd and just toggle
 


### PR DESCRIPTION
Changes are:
1. allow /usr/libexec/ublue-motd as executable, dynamic motd
2. change to /etc/user-motd for static motd, allowing choice to customizate user-motd at runtime if pre-generated is not desired