### PR TITLE
fix(just): correctly return after replacing all containers using Assemble

### DIFF
--- a/build/ublue-os-just/lib-ujust/libdistrobox.sh
+++ b/build/ublue-os-just/lib-ujust/libdistrobox.sh
@@ -74,6 +74,7 @@ function Assemble(){
         fi
         # Run the distrobox assemble command
         distrobox assemble "$ACTION" --file "$FILE" --replace
+        return $?
     else
         # Set distrobox name to provided name
         NAME="$3"


### PR DESCRIPTION
Fixes a bug that Noel found where if you assemble ALL containers, it would try to do it 2 times and freeze on the 2nd try.