### PR TITLE
chore(just): Remove rhel8 and rhel9 toolbox images due to severe incompabilities with distrobox

### DIFF
--- a/build/ublue-os-just/30-distrobox.just
+++ b/build/ublue-os-just/30-distrobox.just
@@ -20,8 +20,6 @@ distrobox-new IMAGE="prompt" NAME="prompt" HOMEDIR="":
     IMAGES='
       New
       Bazzite-arch
-      Rhel8-toolbox
-      Rhel9-toolbox
     '
     IMAGE={{ IMAGE }}
     NAME={{ NAME }}
@@ -62,30 +60,6 @@ distrobox-new IMAGE="prompt" NAME="prompt" HOMEDIR="":
         echo -en "Please enter a name for the container: "
         read NAME
       fi
-      case ${IMAGE,,} in
-        rhel8-toolbox)
-          if ! grep -q "registry.redhat.io" $XDG_RUNTIME_DIR/containers/auth.json; then
-            echo "Please login using your Red Hat Account or Red Hat Developer Account ..."
-            podman login registry.redhat.io
-          fi
-          if [ -z "$NAME" ]; then
-            NAME="rhel8"
-          fi
-          echo 'Creating RHEL 8 distrobox ...'
-          IMAGE="registry.redhat.io/rhel8/toolbox:latest"
-          ;;
-        rhel9-toolbox)
-          if ! grep -q "registry.redhat.io" $XDG_RUNTIME_DIR/containers/auth.json; then
-            echo "Please login using your Red Hat Account or Red Hat Developer Account ..."
-            podman login registry.redhat.io
-          fi
-          if [ -z "$NAME" ]; then
-            NAME="rhel9"
-          fi
-          echo 'Creating RHEL 9 distrobox ...'
-          IMAGE="registry.redhat.io/rhel9/toolbox:latest"
-          ;;
-      esac
     fi
     # Create the distrobox
     Distrobox "$IMAGE" "$NAME" "$HOMEDIR" $ARGS

--- a/build/ublue-os-just/lib-ujust/libdistrobox.sh
+++ b/build/ublue-os-just/lib-ujust/libdistrobox.sh
@@ -98,9 +98,9 @@ function Assemble(){
 ## Function to parse a distrobox.ini file and make a selectable list from it
 ########
 ## Parse a distrobox.ini manifest and let user select which container to setup
-# AssembleParse "$HOME/distrobox.ini" create
+# AssembleList "$HOME/distrobox.ini" create
 ## Parse a distrobox.ini manifest and create ubuntu container without confirmation
-# AssembleParse "$HOME/distrobox.ini" noconfirmcreate ubuntu
+# AssembleList "$HOME/distrobox.ini" noconfirmcreate ubuntu
 function AssembleList (){
     # Set defaults
     FILE="$1"


### PR DESCRIPTION
Relevant bug: https://github.com/89luca89/distrobox/issues/1146
UBI images are fine, they can stay.