### PR TITLE
feat: add udev rules for linksys ae1200 usb dongle

### DIFF
--- a/files/etc/udev/rules.d/30-linksys-ae1200.rules
+++ b/files/etc/udev/rules.d/30-linksys-ae1200.rules
@@ -1,0 +1,5 @@
+# Provides support for the Linksys AE1200 USB dongle. 
+# Since the device ID does not use the "brcmfmac" kernel module, it is added manually. 
+ACTION=="add",ATTRS{idVendor}=="13b1",ATTRS{idProduct}=="0bdc",
+RUN+="/sbin/modprobe brcmfmac"
+RUN+="/bin/sh -c 'echo 13b1 0bdc > /sys/bus/usb/drivers/brcmfmac/new_id'"


### PR DESCRIPTION
Provides support for the Linksys AE1200, a USB dongle that enables WiFi.

Essentially, on normal distros the dongle does not work on boot. It must be physically disconnected and plugged back in to be recognized. Upon closer examination, there seems to be a mismatch between the device ID on boot (`13b1:0bdc`) and the value that `brcmfmac` (the kernel module) accepts (`13b1:0039`). After physically plugging it for the 2nd time, `lsusb` states the correct ID.  

Having this udev rule fixes the issue and WiFi works on boot. Merging this would remove the need to keep the spare `.rules` file.