### PR TITLE
fix(just): update fleek install to the new 0.10x command

### DIFF
--- a/build/ublue-os-just/70-nix.just
+++ b/build/ublue-os-just/70-nix.just
@@ -92,7 +92,7 @@ setup-fleek ACTION="prompt":
     if [ "$OPTION" == "Install Fleek" ] || [ "${OPTION,,}" == "install" ]; then
       mkdir -p $HOME/.config/nix
       echo "experimental-features = nix-command flakes" >> $HOME/.config/nix/nix.conf
-      curl -fsSL https://getfleek.dev/installer | env FORCE=1 bash
+      nix run "https://getfleek.dev/latest.tar.gz" -- init
     elif [ "$OPTION" == "Uninstall Fleek" ] || [ "${OPTION,,}" == "remove" ]; then
       if [[ -x "/var/usrlocal/bin/fleek" ]]; then
         sudo rm -f /var/usrlocal/bin/fleek


### PR DESCRIPTION
Sometime in December 2023, fleek changed their install instructions.
this updates the setup-fleek recipe with the new install command for fleek and fixes #202 