### PR TITLE
fix(distrobox): remove bluefin-dx

### DIFF
--- a/build/ublue-os-just/etc-distrobox/distrobox.ini
+++ b/build/ublue-os-just/etc-distrobox/distrobox.ini
@@ -11,14 +11,6 @@ nvidia=true
 image=ghcr.io/ublue-os/bluefin-cli
 nvidia=true
 
-[bluefin-dx-cli]
-image=ghcr.io/ublue-os/bluefin-dx-cli
-nvidia=true
-
-[boxkit]
-image=ghcr.io/ublue-os/boxkit
-nvidia=true
-
 [debian]
 image=quay.io/toolbx-images/debian-toolbox:unstable
 nvidia=true


### PR DESCRIPTION
This just confuses people, the people who need -dx can use wolfi-dx or run it by hand and wolfi replaces boxkit anyway