### PR TITLE
fix(just): make Urllink remove formating at the end of hyperlink

### DIFF
--- a/build/ublue-os-just/lib-ujust/libformatting.sh
+++ b/build/ublue-os-just/lib-ujust/libformatting.sh
@@ -38,5 +38,5 @@ function Urllink (){
     TEXT=$2
 
     # Generate a clickable hyperlink
-    printf "\e]8;;%s\e\\%s\e]8;;\e\\" "$URL" "$TEXT"
+    printf "\e]8;;%s\e\\%s\e]8;;\e\\" "$URL" "$TEXT${n}"
 }


### PR DESCRIPTION
this is to avoid having to pass `${n}` along with the text for usability
