### PR TITLE
feat: initial brew installer

### DIFF
--- a/build/ublue-os-just/00-default.just
+++ b/build/ublue-os-just/00-default.just
@@ -63,6 +63,30 @@ setup-distrobox-git:
       exit 0
     fi
 
+# installs homebrew on the system
+install-brew:
+    #!/usr/bin/env bash
+    source /usr/lib/ujust/ujust.sh
+    if [[ ! -f "/var/home/linuxbrew/.linuxbrew/bin" || ! -x "/var/home/linuxbrew/.linuxbrew/bin/brew" ]]; then
+        echo "${b}Brew Installation${n}"
+        echo "Please ${b}IGNORE${n} everything the installer tells you to do at the end"
+        echo "We have already done it for you! You just need to close and re-open the terminal after installation"
+        echo "Do you understand?"
+        echo "Please type in \"YES I UNDERSTAND\" and press enter"
+        read ACCEPT
+        if [ "$ACCEPT" == "YES I UNDERSTAND" ]; then
+          curl https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh | /usr/bin/bash -c
+        else
+          echo "Capitalization matters when you type \"YES I UNDERSTAND\""
+        fi
+    fi
+    # if /etc/profile.d/brew.sh already exists, replace it with /usr/etc/profile.d/brew.sh
+    if [ -f /etc/profile.d/brew.sh ]; then
+        if [ -f /usr/etc/profile.d/brew.sh ]; then
+            sudo cp /usr/etc/profile.d/brew.sh /etc/profile.d/brew.sh
+        fi
+    fi
+
 # Removes homebrew from system
 remove-brew:
     echo "Removing homebrew ..."

--- a/build/ublue-os-just/00-default.just
+++ b/build/ublue-os-just/00-default.just
@@ -75,7 +75,7 @@ install-brew:
         echo "Please type in \"YES I UNDERSTAND\" and press enter"
         read ACCEPT
         if [ "$ACCEPT" == "YES I UNDERSTAND" ]; then
-          curl https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh | /usr/bin/bash -c
+          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
         else
           echo "Capitalization matters when you type \"YES I UNDERSTAND\""
         fi

--- a/build/ublue-os-just/build.sh
+++ b/build/ublue-os-just/build.sh
@@ -13,6 +13,7 @@ cp ${SCRIPT_DIR}/lib-ujust/*.sh /tmp/ublue-os/rpmbuild/SOURCES
 cp ${SCRIPT_DIR}/etc-distrobox/*.ini /tmp/ublue-os/rpmbuild/SOURCES
 cp ${SCRIPT_DIR}/etc-profile.d/ublue-os-just.sh /tmp/ublue-os/rpmbuild/SOURCES
 cp ${SCRIPT_DIR}/etc-profile.d/user-motd.sh /tmp/ublue-os/rpmbuild/SOURCES
+cp ${SCRIPT_DIR}/etc-profile.d/brew.sh /tmp/ublue-os/rpmbuild/SOURCES
 cp ${SCRIPT_DIR}/etc-toolbox/toolbox.ini /tmp/ublue-os/rpmbuild/SOURCES
 
 rpmbuild -ba \

--- a/build/ublue-os-just/etc-profile.d/brew.sh
+++ b/build/ublue-os-just/etc-profile.d/brew.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+[[ -d /home/linuxbrew/.linuxbrew && $- == *i* ]] && eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"

--- a/build/ublue-os-just/ublue-os-just.spec
+++ b/build/ublue-os-just/ublue-os-just.spec
@@ -1,7 +1,7 @@
 Name:           ublue-os-just
 Packager:       ublue-os
 Vendor:         ublue-os
-Version:        0.28
+Version:        0.30
 Release:        1%{?dist}
 Summary:        ublue-os just integration
 License:        MIT
@@ -100,7 +100,7 @@ just --completions bash | sed -E 's/([\(_" ])just/\1ujust/g' > %{_datadir}/bash-
 chmod 644 %{_datadir}/bash-completion/completions/ujust
 
 %changelog
-* Sun Mar 23 2024 gerblesh <101901964+gerblesh@users.noreply.github.com> - 0.29
+* Sun Mar 24 2024 gerblesh <101901964+gerblesh@users.noreply.github.com> - 0.30
 - Add brew config to /etc/profile.d
 
 * Fri Feb 23 2024 HikariKnight <2557889+HikariKnight@users.noreply.github.com> - 0.29

--- a/build/ublue-os-just/ublue-os-just.spec
+++ b/build/ublue-os-just/ublue-os-just.spec
@@ -32,6 +32,7 @@ Source19:       user-motd.sh
 Source20:       libtoolbox.sh
 Source21:       toolbox.ini
 Source22:       31-toolbox.just
+Source23:       brew.sh
 
 %global sub_name %{lua:t=string.gsub(rpm.expand("%{NAME}"), "^ublue%-os%-", ""); print(t)}
 
@@ -46,6 +47,7 @@ Adds ublue-os just integration for easier setup
 mkdir -p -m0755  %{buildroot}%{_datadir}/%{VENDOR}/%{sub_name}
 install -Dm755 %{SOURCE0}  %{buildroot}%{_sysconfdir}/profile.d/ublue-os-just.sh
 install -Dm755 %{SOURCE19}  %{buildroot}%{_sysconfdir}/profile.d/user-motd.sh
+install -Dm755 %{SOURCE23}  %{buildroot}%{_sysconfdir}/profile.d/brew.sh
 cp %{SOURCE1} %{SOURCE2} %{SOURCE3} %{SOURCE4} %{SOURCE5} %{SOURCE6} %{SOURCE7} %{SOURCE22} %{buildroot}%{_datadir}/%{VENDOR}/%{sub_name}
 
 # Create justfile which contains all .just files included in this package
@@ -82,6 +84,7 @@ install -Dm644 %{SOURCE21} %{buildroot}/%{_sysconfdir}/toolbox
 %dir %attr(0755,root,root) %{_datadir}/%{VENDOR}/%{sub_name}
 %attr(0755,root,root) %{_sysconfdir}/profile.d/ublue-os-just.sh
 %attr(0755,root,root) %{_sysconfdir}/profile.d/user-motd.sh
+%attr(0755,root,root) %{_sysconfdir}/profile.d/brew.sh
 %attr(0644,root,root) %{_datadir}/%{VENDOR}/%{sub_name}/*.just
 %attr(0644,root,root) %{_datadir}/%{VENDOR}/justfile
 %attr(0755,root,root) %{_bindir}/ujust
@@ -97,6 +100,9 @@ just --completions bash | sed -E 's/([\(_" ])just/\1ujust/g' > %{_datadir}/bash-
 chmod 644 %{_datadir}/bash-completion/completions/ujust
 
 %changelog
+* Sun Mar 23 2024 gerblesh <101901964+gerblesh@users.noreply.github.com> - 0.29
+- Add brew config to /etc/profile.d
+
 * Fri Feb 23 2024 HikariKnight <2557889+HikariKnight@users.noreply.github.com> - 0.29
 - Add option to use toolbox in ujust
 


### PR DESCRIPTION
This PR basically copies the brew installer logic from bluefin:
https://github.com/ublue-os/bluefin/blob/main/usr/etc/profile.d/brew.sh
https://github.com/ublue-os/bluefin/blob/main/Containerfile#L104

only change is using `curl https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh | /usr/bin/bash -c` instead of having the install script directly on the image, might be better to directly pull these scripts down when building to keep consistency