### PR TITLE
fix: add brew alias

### DIFF
--- a/build/ublue-os-just/00-default.just
+++ b/build/ublue-os-just/00-default.just
@@ -63,7 +63,9 @@ setup-distrobox-git:
       exit 0
     fi
 
-# installs homebrew on the system
+alias brew := install-brew
+
+# Install Homebrew | https://brew.sh
 install-brew:
     #!/usr/bin/env bash
     source /usr/lib/ujust/ujust.sh


### PR DESCRIPTION
## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.

This PR adds the missing alias for `brew-install` in 00-default.just