### PR TITLE
feat: added Fido2/Yubi Key Setup with ujust

### DIFF
--- a/build/ublue-os-just/50-akmods.just
+++ b/build/ublue-os-just/50-akmods.just
@@ -29,7 +29,7 @@ configure-broadcom-wl ACTION="prompt":
       echo "${bold}Disabled${normal} Broadcom Wireless, please reboot for changes to take effect"
     fi
 
-# Configure/Add Fido/Yubi key to an Encrypted disk with key priority 
+# Configure/Add Fido/Yubi key to an Encrypted disk with key priority
 configure-fido2:
     #!/usr/bin/bash
     if [ "$EUID" -ne 0 ]
@@ -93,7 +93,6 @@ configure-fido2:
         [Yy]* ) systemd-cryptenroll --fido2-device=auto --fido2-with-user-verification=true $device;;
         *) echo "not enrolling a new key" ;;
     esac
-    ### edit the crypttab like for the luks volume if needed
     luksline=$(grep -r $luks /etc/crypttab)
     if [[ ! "$luksline" = *"fido2-device"* ]] ; then
         opts=$(echo $luksline | awk '{print $4}')

--- a/build/ublue-os-just/50-akmods.just
+++ b/build/ublue-os-just/50-akmods.just
@@ -28,3 +28,57 @@ configure-broadcom-wl ACTION="prompt":
       sudo bash -c 'echo "blacklist wl" > /etc/modules-load.d/default-disable-broadcom-wl.conf'
       echo "${bold}Disabled${normal} Broadcom Wireless, please reboot for changes to take effect"
     fi
+
+# Configure/Add Fido/Yubi key to an Encrypted disk with key priority 
+fido2:
+    #!/usr/bin/bash
+    if [ "$EUID" -ne 0 ]
+        then echo "Please run as root"
+        exit
+    fi
+    clear; lsblk
+    ## find default devices
+    device='/dev/'$(lsblk -r --fs | grep crypto | awk '{print $1}')
+    luks=$(lsblk -r --fs | grep luks | awk '{print $1}')
+    echo " _______________________"
+    echo Your device is $device
+    echo Your crypto volume is $luks
+    # add custom values if needed
+    read -p "are these values correct? y/n" yn
+    case $yn in
+        [Nn]* ) read -p "enter the device volume? " device ; read -p "Enter value for luks volume " luks;;
+    esac
+    ## make sure custom value has /dev added
+    [[ $device = */dev/* ]] || device=/dev/$device
+    clear; lsblk
+    echo Your device is $device
+    echo Your crypto volume is $luks
+    ## enroll a key
+    read -p "do you need to enrol a new key?  if yes insert key before answering  y/n " yn
+    case $yn in
+        [Yy]* ) systemd-cryptenroll --fido2-device=auto --fido2-with-user-verification=true $device;;
+        *) echo "not enrolling a new key" ;;
+    esac
+    ### edit the crypttab like for the luks volume if needed
+    luksline=$(grep -r $luks /etc/crypttab)
+    if [[ ! "$luksline" = *"fido2-device"* ]] ; then
+        opts=$(echo $luksline | awk '{print $4}')
+        newopts=$(echo $luksline | sed "s/$opts/fido2-device=auto,$opts/g")
+        sed -i "s/$luksline/$newopts/g" /etc/crypttab
+        echo "updated crypttab with fido"
+    fi
+    ### sets the password to not be used unless a key is not present
+    read -p "Set the new key as the sufficient auth method? y/n " yn
+    case $yn in
+        [Yy]* ) cryptsetup config --key-slot 0 --priority ignore $device ; cryptsetup config --key-slot 1 --priority prefer $device;;
+        *) echo "leaving slot priorities the same" ;;
+    esac
+    ## show deplyments to see custom initramfs options,
+    rpm-ostree status
+    ## rebuilds the initramfs with --fido2 then shows deployments to confirm the change
+    read -p "Rebuild initramfs with fido module ? y/n " yn
+    case $yn in
+        [Yy]* ) rpm-ostree initramfs --enable --arg='--add' --arg='fido2' ; clear ; rpm-ostree status;;
+        *) echo "initramfs not rebuilding" ;;
+    esac
+    echo "Fido2 setup complete,  next reboot will ask for a key"

--- a/build/ublue-os-just/50-akmods.just
+++ b/build/ublue-os-just/50-akmods.just
@@ -30,32 +30,66 @@ configure-broadcom-wl ACTION="prompt":
     fi
 
 # Configure/Add Fido/Yubi key to an Encrypted disk with key priority 
-fido2:
+configure-fido2:
     #!/usr/bin/bash
     if [ "$EUID" -ne 0 ]
         then echo "Please run as root"
         exit
     fi
-    clear; lsblk
-    ## find default devices
-    device='/dev/'$(lsblk -r --fs | grep crypto | awk '{print $1}')
-    luks=$(lsblk -r --fs | grep luks | awk '{print $1}')
-    echo " _______________________"
-    echo Your device is $device
-    echo Your crypto volume is $luks
-    # add custom values if needed
-    read -p "are these values correct? y/n" yn
-    case $yn in
-        [Nn]* ) read -p "enter the device volume? " device ; read -p "Enter value for luks volume " luks;;
-    esac
-    ## make sure custom value has /dev added
+    device=""
+    luk=""
+    clear; readarray devices <<< $(lsblk -r --fs | grep crypto | awk '{print $1}')
+    readarray luks <<< $(lsblk -r --fs | grep luks | awk '{print $1}')
+    if [ "${#devices[@]}" -gt 1 ]; then
+      while true; do
+          echo "select q to quit at anytime"
+          for ((i = 0; i < ${#devices[@]}; ++i)); do
+               echo $(echo "$i: ${devices[$i]}" | sed -e 's/\\n//g')
+          done
+          read -p "Select which device you want to work with using the number:  " choice
+          clear
+          case $choice in
+            [Qq]*) exit;;
+            ''|*[!0-9]*) echo "invalid selection, please use the numbers or q to quit" ;;
+            *) device="${devices[$choice]}"; [[ ! -z $device ]] && break || echo "invalid choice";;
+          esac
+
+      done
+    else
+        device=$(echo "${devices[0]}" | sed -e 's/\\n//g')
+        [[ ! "$device"  =~ [:alnum:] ]] && echo "No devices with crypto active ... exiting" && exit
+    fi
+    if [ "${#luks[@]}" -gt 1 ]; then
+      while true; do
+          for ((i = 0; i < ${#luks[@]}; ++i)); do
+               echo $(echo "$i: ${luks[$i]}" | sed -e 's/\\n//g')
+          done
+          read -p "Select which volume you want to work with using the number:  " choice
+          clear
+          case $choice in
+            [Qq]*) exit;;
+            ''|*[!0-9]*) echo "invalid selection, please use the numbers or q to quit" ;;
+            *) luk="${luks[$choice]}"; [[ ! -z $luk ]] && break || echo "invalid choice";;
+          esac
+
+      done
+    else
+        luk=$(echo "${luks[0]}" | sed -e 's/\\n//g')
+        [[ ! "$luk"  =~ [:alnum:] ]] && echo "No devices with crypto active ... exiting" && exit
+    fi
     [[ $device = */dev/* ]] || device=/dev/$device
-    clear; lsblk
-    echo Your device is $device
-    echo Your crypto volume is $luks
-    ## enroll a key
-    read -p "do you need to enrol a new key?  if yes insert key before answering  y/n " yn
-    case $yn in
+    clear;
+    echo "Your device is $device  with volume $luk"
+    read -p "confirm choices y/n  or quit q " choice
+    clear
+    case $choice in
+      [Qq]*) exit;;
+      [Yy]*) : ;;
+      *) echo "invalid choice, exiting"; exit;;
+    esac
+
+    read -p "do you need to enrol a new key?  if yes insert key before answering  y/n " choice
+    case $choice in
         [Yy]* ) systemd-cryptenroll --fido2-device=auto --fido2-with-user-verification=true $device;;
         *) echo "not enrolling a new key" ;;
     esac
@@ -67,18 +101,48 @@ fido2:
         sed -i "s/$luksline/$newopts/g" /etc/crypttab
         echo "updated crypttab with fido"
     fi
-    ### sets the password to not be used unless a key is not present
-    read -p "Set the new key as the sufficient auth method? y/n " yn
-    case $yn in
-        [Yy]* ) cryptsetup config --key-slot 0 --priority ignore $device ; cryptsetup config --key-slot 1 --priority prefer $device;;
-        *) echo "leaving slot priorities the same" ;;
+    dracutfile="/etc/dracut.conf.d/fido2.conf"
+    if [ ! -f $dracutfile ]; then
+        echo 'add_dracutmodules+=" fido2 "
+    force_drivers+=" fido2 "' > $dracutfile
+        echo "created fido2 dracut.conf"
+    else
+        mods="$(grep -r "add_dracutmodules+=" $dracutfile)"
+        if [[ $mods = *"dracutmodules+="* ]] ; then
+            if [[ ! $mods = *"fido2"* ]] ; then
+                sed -i 's/add_dracutmodules+="/add_dracutmodules+=" fido2 /g' "$dracutfile"
+            fi
+        else
+            echo 'add_dracutmodules+=" fido2 "' >> $dracutfile
+        fi
+        drivers="$(grep -r "force_drivers+=" $dracutfile)"
+        if [[ $drivers = *"force_drivers+="* ]] ; then
+            if [[ ! $drivers = *"fido2"* ]] ; then
+                sed -i 's/force_drivers+="/force_drivers+=" fido2 /g' "$dracutfile"
+            fi
+        else
+            echo 'force_drivers+=" fido2 "' >> $dracutfile
+        fi
+        echo "updated fido2 dracut.conf"
+    fi
+    echo "
+
+    Set the slot priority of the of the password and fido
+    0: fido preferred, password ignored  | WARNING !!  This will ONLY allow the fido to unlock
+    1: fido preferred, password normal   | This will allow the password to be used if fido isnt present
+    "
+    read -p ": " choice
+    case $choice in
+        [0] ) cryptsetup config --key-slot 0 --priority ignore $device ; cryptsetup config --key-slot 1 --priority prefer $device;;
+        [1] ) cryptsetup config --key-slot 0 --priority normal $device ; cryptsetup config --key-slot 1 --priority prefer $device;;
+        *) echo "invalid option,  leaving slot priorities the same" ;;
     esac
-    ## show deplyments to see custom initramfs options,
-    rpm-ostree status
-    ## rebuilds the initramfs with --fido2 then shows deployments to confirm the change
-    read -p "Rebuild initramfs with fido module ? y/n " yn
-    case $yn in
-        [Yy]* ) rpm-ostree initramfs --enable --arg='--add' --arg='fido2' ; clear ; rpm-ostree status;;
+    echo "
+
+    "
+    read -p "Enable the initramfs to rebuild ?  y/n " choice
+    case $choice in
+        [Yy]* ) rpm-ostree initramfs --enable;;
         *) echo "initramfs not rebuilding" ;;
     esac
-    echo "Fido2 setup complete,  next reboot will ask for a key"
+    echo " Fido Configuration complete "


### PR DESCRIPTION
This addition creates a ujust script that allows easy config of a fido/yubi key on to an encrypted disk.
it provides options to:
- enrol a new key
- manually assign device and luks volume if you have multiple encrypted disks
- set the key has the default method.   This allows the key to be the only auth method needed and password as fallback.  Great for steamdeck use if fido key doesnt need a passphrase as it doesnt yet have a onscreen keyboard for this
- rebuilds initramfs with fido module - its an option incase you want to do thjis for multiple volumes, it doesnt need rebuilding again.
and it updates /etc/crypttab with fido option for selected volume if needed