### PR TITLE
feat: Toggle omz script

### DIFF
--- a/build/ublue-os-just/01-omz.just
+++ b/build/ublue-os-just/01-omz.just
@@ -1,0 +1,17 @@
+alias toggle-omz := toggle-ohmyzsh
+
+toggle-ohmyzsh:
+	#!/bin/bash
+	/usr/libexec/toggle_omz.sh
+
+alias install-omz := install-ohmyzsh
+
+install-ohmyzsh:
+	#!/bin/bash
+	/usr/libexec/toggle_omz.sh install
+
+alias uninstall-omz := uninstall-ohmyzsh
+
+uninstall-ohmyzsh:
+	#!/bin/bash
+	/usr/libexec/toggle_omz.sh uninstall

--- a/build/ublue-os-just/01-omz.just
+++ b/build/ublue-os-just/01-omz.just
@@ -1,17 +1,17 @@
 alias toggle-omz := toggle-ohmyzsh
 
 toggle-ohmyzsh:
-	#!/bin/bash
-	/usr/libexec/toggle_omz.sh
+		#!/bin/bash
+		/usr/libexec/toggle_omz.sh
 
 alias install-omz := install-ohmyzsh
 
 install-ohmyzsh:
-	#!/bin/bash
-	/usr/libexec/toggle_omz.sh install
+		#!/bin/bash
+		/usr/libexec/toggle_omz.sh install
 
 alias uninstall-omz := uninstall-ohmyzsh
 
 uninstall-ohmyzsh:
-	#!/bin/bash
-	/usr/libexec/toggle_omz.sh uninstall
+		 #!/bin/bash
+		/usr/libexec/toggle_omz.sh uninstall

--- a/build/ublue-os-just/01-omz.just
+++ b/build/ublue-os-just/01-omz.just
@@ -1,17 +1,17 @@
 alias toggle-omz := toggle-ohmyzsh
 
 toggle-ohmyzsh:
-		#!/bin/bash
-		/usr/libexec/toggle_omz.sh
+    #!/bin/bash
+    /usr/libexec/toggle_omz.sh
 
 alias install-omz := install-ohmyzsh
 
 install-ohmyzsh:
-		#!/bin/bash
-		/usr/libexec/toggle_omz.sh install
+    #!/bin/bash
+    /usr/libexec/toggle_omz.sh install
 
 alias uninstall-omz := uninstall-ohmyzsh
 
 uninstall-ohmyzsh:
-		 #!/bin/bash
-		/usr/libexec/toggle_omz.sh uninstall
+    #!/bin/bash
+    /usr/libexec/toggle_omz.sh uninstall

--- a/files/usr/libexec/toggle_omz.sh
+++ b/files/usr/libexec/toggle_omz.sh
@@ -2,6 +2,12 @@
 
 install_omz()
 {
+	if [ -d "$HOME/.oh-my-zsh" ]
+	then
+		echo "ohmyzsh is already installed."
+		exit 1
+	fi
+
 	if ! command -v zsh &> /dev/null
 	then
 		echo "Unable to install ohmyzsh. Please install zsh first."
@@ -54,6 +60,12 @@ install_omz()
 
 uninstall_omz()
 {
+	if ! [ -d "$HOME/.oh-my-zsh" ]
+	then
+		echo "ohmyzsh was not found. Uninstall failed."
+		exit 1
+	fi
+
 	# Add missing permissions so the script can run
 	# Note: You're supposed to have a command to uninstall omz,
 	# but it doesn't seem to work from scripts, so I just run the script this command calls.

--- a/files/usr/libexec/toggle_omz.sh
+++ b/files/usr/libexec/toggle_omz.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+
+install_omz()
+{
+	if ! command -v zsh &> /dev/null
+	then
+		echo "Unable to install ohmyzsh. Please install zsh first."
+		exit 1
+	fi
+
+	if ! command -v git &> /dev/null
+	then
+		# Assuming this is running on fedora atomic, this shouldn't happen on the host.
+		# Unless there's an override to remove git.
+		# This can also happen if this script is running in a container.
+		echo "Unable to install ohmyzsh. Please install git first."
+		exit 1
+	fi
+
+	# Either curl, wget or fetch are required. Only one of them will be used.
+	if command -v curl &> /dev/null
+	then
+		request_command="curl -fsSL"
+	elif command -v wget &> /dev/null
+	then
+		request_command="wget -O-"
+	elif command -v fetch &> /dev/null
+	then
+		request_command="fetch -o -"
+	else
+		echo "Unable to install ohmyzsh. Please install either curl, wget or fetch first."
+		echo "Note: fetch is not officially packaged by fedora. curl and wget are recommended."
+		exit 1
+	fi
+
+	if [ "$1" = false ]
+	then
+		install="y"
+	else
+		echo "Do you want to install ohmyzsh? (y/n)"
+		read install
+	fi
+
+	if [[ "$install" =~ ^([yY][eE][sS]|[yY])$ ]]
+	then
+		if [ "$1" = false ]
+		then
+			CHSH=no sh -c "$($request_command https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+		else
+			sh -c "$($request_command https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+		fi
+	fi
+}
+
+uninstall_omz()
+{
+	# Add missing permissions so the script can run
+	# Note: You're supposed to have a command to uninstall omz,
+	# but it doesn't seem to work from scripts, so I just run the script this command calls.
+	chmod u+x $HOME/.oh-my-zsh/tools/uninstall.sh
+
+	if [[ "$1" = false ]]
+	then
+		# Uninstalling non interactively
+		yes | $HOME/.oh-my-zsh/tools/uninstall.sh
+	else
+		# Installing interactively
+		$HOME/.oh-my-zsh/tools/uninstall.sh
+	fi
+}
+
+# Initialize `$interactive` default value
+interactive=true
+
+# Main
+for i in $@
+do
+	case $i in
+		install)
+			subcommand="install"
+			;;
+		uninstall)
+			subcommand="uninstall"
+			;;
+		-i|--interactive)
+			interactive=true
+			;;
+		-n|--non-interactive)
+			interactive=false
+			;;
+		-h|--help)
+			echo "Use this script to install or uninstall ohmyzsh easily!"
+			echo "Subcommands:"
+			echo "    install -> Install ohmyzsh"
+			echo "    uninstall -> Uninstall ohmyzsh"
+			echo "Flags:"
+			echo "    -i / --interactive -> Use this script interactively (Default)"
+			echo "    -n / --non-interactive -> Use this script non interactively"
+			echo "    -h / --help -> Print this help page and exit"
+			exit
+			;;
+		*)
+			echo "Unrecognized argument: $i"
+			exit 1
+			;;
+	esac
+done
+
+
+
+if [[ "$subcommand" == "install" ]]
+then
+	install_omz $interactive
+elif [[ "$subcommand" == "uninstall" ]]
+then
+	uninstall_omz $interactive
+else
+	if [ -d "$HOME/.oh-my-zsh" ]
+	then
+		echo "ohmyzsh is already installed."
+		if [ "$interactive" = false ]
+		then
+			echo "If you want to uninstall it, either use interactive mode, or the uninstall subcommand."
+		else
+			echo "Do you want to uninstall it? (y/n)"
+			read uninstall
+
+			if [[ "$uninstall" =~ ^([yY][eE][sS]|[yY])$ ]]
+			then
+				uninstall_omz $interactive
+			fi
+		fi
+
+		# Exit since we don't need to go through the rest of the script
+		exit
+	fi
+
+	install_omz $interactive
+fi


### PR DESCRIPTION
## Description
Adding a script to install/uninstall `ohmyzsh` easily, and adding `just` recipes for it. The reason the implementation is in a separate script and not directly in the just files, is to make this script usable in `yafti` as well.

## Context
This feature is related to #246. I've already tested this downstream and I'm proposing this upstream because @castrojo showed interest in adding this feature to Bluefin as well.

## Usage
### shell script
The shell script can either be called directly, without argument, in which case it will check if `omz` is already installed, if it is it will propose the user to uninstall it. Otherwise it will propose the user to install it.

You can directly call the `install` or `uninstall` subcommands as arguments.

These flags are also available:
- `-i` / `--interactive` -> Use this script interactively (Default).
- `-n` / `--non-interactive` -> Use this script non interactively (This is especially useful if you want to call this from a GUI.
- `-h` / `--help` -> Print this help page and exit.

### just recipes
There are three `just` recipes available:
- `ujust toggle-ohmyzsh` / `ujust toggle-omz` -> Install `ohmyzsh` if it's not installed, uninstall it if it's already installed.
- `ujust install-ohmyzsh` / `ujust install-omz` -> Install `ohmyzsh`.
- `ujust uninstall-ohmyzsh` / `ujust-uninstall-omz` -> Uninstall `ohmyzsh`.

## Additional note
You might need to logout/log back in or restart when `chsh` for the change to work correctly.

## Testing
- Run `ujust toggle-omz` twice.
- Run `ujust install-omz`.
- Run `ujust uninstall-omz`.
- You can also play around with the shell script directly.