### PR TITLE
feat: added ujust toggle-release command

### DIFF
--- a/build/ublue-os-just/00-default.just
+++ b/build/ublue-os-just/00-default.just
@@ -153,3 +153,52 @@ device-info:
     #!/usr/bin/bash
     echo "Gathering device info..."
     fpaste <(rpm-ostree status) <(fpaste --sysinfo --printonly)
+    
+# Rebase to another release
+toggle-release ACTION="prompt":
+	#!/usr/bin/env bash
+	source /usr/lib/ujust/ujust.sh
+	CURRENT_IMAGE=$(rpm-ostree status -b --json | jq -r '.deployments[0]."container-image-reference"' | sed -E 's/^.+\/(.+:.+)$/\1/')
+	CURRENT_IMAGE_BASE=$(rpm-ostree status -b --json | jq -r '.deployments[0]."base-commit-meta"."ostree.container.image-config"' | jq -r '.config.Labels."org.opencontainers.image.title"')
+	CURRENT_IMAGE_VERSION=$(rpm-ostree status -b --json | jq -r '.deployments[0]."base-commit-meta"."ostree.container.image-config"' | jq -r '.config.Labels."org.opencontainers.image.version"' | sed -r 's/[.](.*)//g')
+	CURRENT_URI=$(rpm-ostree status -b --json | jq -r '.deployments[0]."container-image-reference"' | sed -E 's/^(.+\/).+:.+$/\1/')
+	OPTION={{ ACTION }}
+	if [ "$OPTION" == "prompt" ]; then
+		echo "${bold}Version Rebase${normal}"
+		echo "Current release: $CURRENT_IMAGE"
+		echo 'Which version would you like to rebase to?'
+		OPTION=$(ugum choose "Latest" "GTS" "40" "39" "38")
+	elif ["$OPTION" == "help" ]; then
+		echo "Usage: ujust toggle-release <option>"
+		echo "	<option>: Specify the quick option - 'latest', 'gts', '40', '39', or '38'"
+		echo "	Use 'latest' to currently rebase to F39"
+		echo "	Use 'gts' to currently rebase to F38"
+		echo "	Use '40' to lock device to F40"
+		echo "	Use '39' to lock device to F39"
+		echo "	Use '38' to lock device to F38"
+		exit 0
+	fi
+	if [ "$OPTION" == "$CURRENT_IMAGE_VERSION" ]; then
+		echo " ${green}${bold}You are already on this release!${normal}"
+		exit 0
+	fi
+	if [ "$OPTION" == "Latest" ]; then
+		echo "${bold}Rebasing to $CURRENT_IMAGE_BASE:latest${normal}"
+		rpm-ostree rebase "$CURRENT_URI$CURRENT_IMAGE_BASE:latest"
+	fi
+	if [ "$OPTION" == "GTS" ]; then
+		echo "${bold}Rebasing to $CURRENT_IMAGE_BASE:gts${normal}"
+		rpm-ostree rebase "$CURRENT_URI$CURRENT_IMAGE_BASE:gts"
+	fi
+	if [ "$OPTION" == "40" ]; then
+		echo "${bold}Rebasing to $CURRENT_IMAGE_BASE:40${normal}"
+		rpm-ostree rebase "$CURRENT_URI$CURRENT_IMAGE_BASE:40"
+	fi
+	if [ "$OPTION" == "39" ]; then
+		echo "${bold}Rebasing to $CURRENT_IMAGE_BASE:39${normal}"
+		rpm-ostree rebase "$CURRENT_URI$CURRENT_IMAGE_BASE:39"
+	fi
+	if [ "$OPTION" == "38" ]; then
+		echo "${bold}Rebasing to $CURRENT_IMAGE_BASE:38${normal}"
+		rpm-ostree rebase "$CURRENT_URI$CURRENT_IMAGE_BASE:38"
+	fi

--- a/build/ublue-os-just/00-default.just
+++ b/build/ublue-os-just/00-default.just
@@ -170,12 +170,12 @@ toggle-release ACTION="prompt":
 	    OPTION=$(ugum choose "Latest" "GTS" "40" "39" "38")
     elif ["$OPTION" == "help" ]; then
 	    echo "Usage: ujust toggle-release <option>"
-	    echo "	<option>: Specify the quick option - 'latest', 'gts', '40', '39', or '38'"
-	    echo "	Use 'latest' to currently rebase to F39"
-	    echo "	Use 'gts' to currently rebase to F38"
-	    echo "	Use '40' to lock device to F40"
-	    echo "	Use '39' to lock device to F39"
-	    echo "	Use '38' to lock device to F38"
+	    echo "  <option>: Specify the quick option - 'latest', 'gts', '40', '39', or '38'"
+	    echo "  Use 'latest' to currently rebase to F39"
+	    echo "  Use 'gts' to currently rebase to F38"
+	    echo "  Use '40' to lock device to F40"
+	    echo "  Use '39' to lock device to F39"
+	    echo "  Use '38' to lock device to F38"
 	    exit 0
     fi
     if [ "$OPTION" == "$CURRENT_IMAGE_VERSION" ]; then

--- a/build/ublue-os-just/00-default.just
+++ b/build/ublue-os-just/00-default.just
@@ -182,11 +182,11 @@ toggle-release ACTION="prompt":
 		echo " ${green}${bold}You are already on this release!${normal}"
 		exit 0
 	fi
-	if [ "$OPTION" == "Latest" ]; then
+	if [ "$OPTION" == "Latest" || "$OPTION" == "latest" ]; then
 		echo "${bold}Rebasing to $CURRENT_IMAGE_BASE:latest${normal}"
 		rpm-ostree rebase "$CURRENT_URI$CURRENT_IMAGE_BASE:latest"
 	fi
-	if [ "$OPTION" == "GTS" ]; then
+	if [ "$OPTION" == "GTS" || "$OPTION" == "gts" ]; then
 		echo "${bold}Rebasing to $CURRENT_IMAGE_BASE:gts${normal}"
 		rpm-ostree rebase "$CURRENT_URI$CURRENT_IMAGE_BASE:gts"
 	fi

--- a/build/ublue-os-just/00-default.just
+++ b/build/ublue-os-just/00-default.just
@@ -156,49 +156,49 @@ device-info:
     
 # Rebase to another release
 toggle-release ACTION="prompt":
-	#!/usr/bin/env bash
-	source /usr/lib/ujust/ujust.sh
-	CURRENT_IMAGE=$(rpm-ostree status -b --json | jq -r '.deployments[0]."container-image-reference"' | sed -E 's/^.+\/(.+:.+)$/\1/')
-	CURRENT_IMAGE_BASE=$(rpm-ostree status -b --json | jq -r '.deployments[0]."base-commit-meta"."ostree.container.image-config"' | jq -r '.config.Labels."org.opencontainers.image.title"')
-	CURRENT_IMAGE_VERSION=$(rpm-ostree status -b --json | jq -r '.deployments[0]."base-commit-meta"."ostree.container.image-config"' | jq -r '.config.Labels."org.opencontainers.image.version"' | sed -r 's/[.](.*)//g')
-	CURRENT_URI=$(rpm-ostree status -b --json | jq -r '.deployments[0]."container-image-reference"' | sed -E 's/^(.+\/).+:.+$/\1/')
-	OPTION={{ ACTION }}
-	if [ "$OPTION" == "prompt" ]; then
-		echo "${bold}Version Rebase${normal}"
-		echo "Current release: $CURRENT_IMAGE"
-		echo 'Which version would you like to rebase to?'
-		OPTION=$(ugum choose "Latest" "GTS" "40" "39" "38")
-	elif ["$OPTION" == "help" ]; then
-		echo "Usage: ujust toggle-release <option>"
-		echo "	<option>: Specify the quick option - 'latest', 'gts', '40', '39', or '38'"
-		echo "	Use 'latest' to currently rebase to F39"
-		echo "	Use 'gts' to currently rebase to F38"
-		echo "	Use '40' to lock device to F40"
-		echo "	Use '39' to lock device to F39"
-		echo "	Use '38' to lock device to F38"
-		exit 0
-	fi
-	if [ "$OPTION" == "$CURRENT_IMAGE_VERSION" ]; then
-		echo " ${green}${bold}You are already on this release!${normal}"
-		exit 0
-	fi
-	if [ "$OPTION" == "Latest" || "$OPTION" == "latest" ]; then
-		echo "${bold}Rebasing to $CURRENT_IMAGE_BASE:latest${normal}"
-		rpm-ostree rebase "$CURRENT_URI$CURRENT_IMAGE_BASE:latest"
-	fi
-	if [ "$OPTION" == "GTS" || "$OPTION" == "gts" ]; then
-		echo "${bold}Rebasing to $CURRENT_IMAGE_BASE:gts${normal}"
-		rpm-ostree rebase "$CURRENT_URI$CURRENT_IMAGE_BASE:gts"
-	fi
-	if [ "$OPTION" == "40" ]; then
-		echo "${bold}Rebasing to $CURRENT_IMAGE_BASE:40${normal}"
-		rpm-ostree rebase "$CURRENT_URI$CURRENT_IMAGE_BASE:40"
-	fi
-	if [ "$OPTION" == "39" ]; then
-		echo "${bold}Rebasing to $CURRENT_IMAGE_BASE:39${normal}"
-		rpm-ostree rebase "$CURRENT_URI$CURRENT_IMAGE_BASE:39"
-	fi
-	if [ "$OPTION" == "38" ]; then
-		echo "${bold}Rebasing to $CURRENT_IMAGE_BASE:38${normal}"
-		rpm-ostree rebase "$CURRENT_URI$CURRENT_IMAGE_BASE:38"
-	fi
+    #!/usr/bin/env bash
+    source /usr/lib/ujust/ujust.sh
+    CURRENT_IMAGE=$(rpm-ostree status -b --json | jq -r '.deployments[0]."container-image-reference"' | sed -E 's/^.+\/(.+:.+)$/\1/')
+    CURRENT_IMAGE_BASE=$(rpm-ostree status -b --json | jq -r '.deployments[0]."base-commit-meta"."ostree.container.image-config"' | jq -r '.config.Labels."org.opencontainers.image.title"')
+    CURRENT_IMAGE_VERSION=$(rpm-ostree status -b --json | jq -r '.deployments[0]."base-commit-meta"."ostree.container.image-config"' | jq -r '.config.Labels."org.opencontainers.image.version"' | sed -r 's/[.](.*)//g')
+    CURRENT_URI=$(rpm-ostree status -b --json | jq -r '.deployments[0]."container-image-reference"' | sed -E 's/^(.+\/).+:.+$/\1/')
+    OPTION={{ ACTION }}
+    if [ "$OPTION" == "prompt" ]; then
+	    echo "${bold}Version Rebase${normal}"
+	    echo "Current release: $CURRENT_IMAGE"
+	    echo 'Which version would you like to rebase to?'
+	    OPTION=$(ugum choose "Latest" "GTS" "40" "39" "38")
+    elif ["$OPTION" == "help" ]; then
+	    echo "Usage: ujust toggle-release <option>"
+	    echo "	<option>: Specify the quick option - 'latest', 'gts', '40', '39', or '38'"
+	    echo "	Use 'latest' to currently rebase to F39"
+	    echo "	Use 'gts' to currently rebase to F38"
+	    echo "	Use '40' to lock device to F40"
+	    echo "	Use '39' to lock device to F39"
+	    echo "	Use '38' to lock device to F38"
+	    exit 0
+    fi
+    if [ "$OPTION" == "$CURRENT_IMAGE_VERSION" ]; then
+	    echo " ${green}${bold}You are already on this release!${normal}"
+	    exit 0
+    fi
+    if [ "$OPTION" == "Latest" || "$OPTION" == "latest" ]; then
+	    echo "${bold}Rebasing to $CURRENT_IMAGE_BASE:latest${normal}"
+	    rpm-ostree rebase "$CURRENT_URI$CURRENT_IMAGE_BASE:latest"
+    fi
+    if [ "$OPTION" == "GTS" || "$OPTION" == "gts" ]; then
+	    echo "${bold}Rebasing to $CURRENT_IMAGE_BASE:gts${normal}"
+	    rpm-ostree rebase "$CURRENT_URI$CURRENT_IMAGE_BASE:gts"
+    fi
+    if [ "$OPTION" == "40" ]; then
+	    echo "${bold}Rebasing to $CURRENT_IMAGE_BASE:40${normal}"
+	    rpm-ostree rebase "$CURRENT_URI$CURRENT_IMAGE_BASE:40"
+    fi
+    if [ "$OPTION" == "39" ]; then
+	    echo "${bold}Rebasing to $CURRENT_IMAGE_BASE:39${normal}"
+	    rpm-ostree rebase "$CURRENT_URI$CURRENT_IMAGE_BASE:39"
+    fi
+    if [ "$OPTION" == "38" ]; then
+	    echo "${bold}Rebasing to $CURRENT_IMAGE_BASE:38${normal}"
+	    rpm-ostree rebase "$CURRENT_URI$CURRENT_IMAGE_BASE:38"
+    fi

--- a/build/ublue-os-just/00-default.just
+++ b/build/ublue-os-just/00-default.just
@@ -164,41 +164,41 @@ toggle-release ACTION="prompt":
     CURRENT_URI=$(rpm-ostree status -b --json | jq -r '.deployments[0]."container-image-reference"' | sed -E 's/^(.+\/).+:.+$/\1/')
     OPTION={{ ACTION }}
     if [ "$OPTION" == "prompt" ]; then
-	    echo "${bold}Version Rebase${normal}"
-	    echo "Current release: $CURRENT_IMAGE"
-	    echo 'Which version would you like to rebase to?'
-	    OPTION=$(ugum choose "Latest" "GTS" "40" "39" "38")
+        echo "${bold}Version Rebase${normal}"
+        echo "Current release: $CURRENT_IMAGE"
+        echo 'Which version would you like to rebase to?'
+        OPTION=$(ugum choose "Latest" "GTS" "40" "39" "38")
     elif ["$OPTION" == "help" ]; then
-	    echo "Usage: ujust toggle-release <option>"
-	    echo "  <option>: Specify the quick option - 'latest', 'gts', '40', '39', or '38'"
-	    echo "  Use 'latest' to currently rebase to F39"
-	    echo "  Use 'gts' to currently rebase to F38"
-	    echo "  Use '40' to lock device to F40"
-	    echo "  Use '39' to lock device to F39"
-	    echo "  Use '38' to lock device to F38"
-	    exit 0
+        echo "Usage: ujust toggle-release <option>"
+        echo "  <option>: Specify the quick option - 'latest', 'gts', '40', '39', or '38'"
+        echo "  Use 'latest' to currently rebase to F39"
+        echo "  Use 'gts' to currently rebase to F38"
+        echo "  Use '40' to lock device to F40"
+        echo "  Use '39' to lock device to F39"
+        echo "  Use '38' to lock device to F38"
+        exit 0
     fi
     if [ "$OPTION" == "$CURRENT_IMAGE_VERSION" ]; then
-	    echo " ${green}${bold}You are already on this release!${normal}"
-	    exit 0
+        echo " ${green}${bold}You are already on this release!${normal}"
+        exit 0
     fi
     if [ "$OPTION" == "Latest" || "$OPTION" == "latest" ]; then
-	    echo "${bold}Rebasing to $CURRENT_IMAGE_BASE:latest${normal}"
-	    rpm-ostree rebase "$CURRENT_URI$CURRENT_IMAGE_BASE:latest"
+        echo "${bold}Rebasing to $CURRENT_IMAGE_BASE:latest${normal}"
+        rpm-ostree rebase "$CURRENT_URI$CURRENT_IMAGE_BASE:latest"
     fi
     if [ "$OPTION" == "GTS" || "$OPTION" == "gts" ]; then
-	    echo "${bold}Rebasing to $CURRENT_IMAGE_BASE:gts${normal}"
-	    rpm-ostree rebase "$CURRENT_URI$CURRENT_IMAGE_BASE:gts"
+        echo "${bold}Rebasing to $CURRENT_IMAGE_BASE:gts${normal}"
+        rpm-ostree rebase "$CURRENT_URI$CURRENT_IMAGE_BASE:gts"
     fi
     if [ "$OPTION" == "40" ]; then
-	    echo "${bold}Rebasing to $CURRENT_IMAGE_BASE:40${normal}"
-	    rpm-ostree rebase "$CURRENT_URI$CURRENT_IMAGE_BASE:40"
+        echo "${bold}Rebasing to $CURRENT_IMAGE_BASE:40${normal}"
+        rpm-ostree rebase "$CURRENT_URI$CURRENT_IMAGE_BASE:40"
     fi
     if [ "$OPTION" == "39" ]; then
-	    echo "${bold}Rebasing to $CURRENT_IMAGE_BASE:39${normal}"
-	    rpm-ostree rebase "$CURRENT_URI$CURRENT_IMAGE_BASE:39"
+        echo "${bold}Rebasing to $CURRENT_IMAGE_BASE:39${normal}"
+        rpm-ostree rebase "$CURRENT_URI$CURRENT_IMAGE_BASE:39"
     fi
     if [ "$OPTION" == "38" ]; then
-	    echo "${bold}Rebasing to $CURRENT_IMAGE_BASE:38${normal}"
-	    rpm-ostree rebase "$CURRENT_URI$CURRENT_IMAGE_BASE:38"
+        echo "${bold}Rebasing to $CURRENT_IMAGE_BASE:38${normal}"
+        rpm-ostree rebase "$CURRENT_URI$CURRENT_IMAGE_BASE:38"
     fi

--- a/build/ublue-os-just/00-default.just
+++ b/build/ublue-os-just/00-default.just
@@ -153,7 +153,7 @@ device-info:
     #!/usr/bin/bash
     echo "Gathering device info..."
     fpaste <(rpm-ostree status) <(fpaste --sysinfo --printonly)
-    
+
 # Rebase to another release
 toggle-release ACTION="prompt":
     #!/usr/bin/env bash


### PR DESCRIPTION
# Description
This implements the feature mentioned in #251. I've tested it locally on my bluefin-nvidia install.

# Usage
- Run `ujust toggle-release` to get a selection menu of available releases. Enter on the release you want and it should trigger an appropriate `rpm-ostree rebase` for your current image.
- Run `ujust toggle-release <option>` to directly run the rebase; skipping the selection menu e.g. `ujust toggle-release 39`. Available options:
	- `latest`
	- `gts`
	- `40`
	- `39`
	- `38`
- Selecting the same release as currently installed will result in a message `You are already on this release!` and it will exit the script.
- Run `ujust toggle-release help` to see the description on how to use this command.