### PR TITLE
Change fedora-distrobox to *-toolbox in distrobox.ini

### DIFF
--- a/build/ublue-os-just/etc-distrobox/distrobox.ini
+++ b/build/ublue-os-just/etc-distrobox/distrobox.ini
@@ -16,7 +16,7 @@ image=quay.io/toolbx-images/debian-toolbox:unstable
 nvidia=true
 
 [fedora]
-image=ghcr.io/ublue-os/fedora-distrobox:latest
+image=ghcr.io/ublue-os/fedora-toolbox:latest
 nvidia=true
 
 [opensuse]


### PR DESCRIPTION
- [ ] TODO test this on my system first :facepalm:

# Change summary
Feel free to reject this change - this is simply a hunch.

I changed [fedora] in `/etc/distrobox/distrobox.ini` to use `ublue-os/fedora-toolbox:latest` instead of `ublue-os/fedora-distrobox:latest`.

- On one hand, `ujust distrobox-assemble fedora` pulls from `ublue-os/fedora-distrobox:latest`. 
- On the other hand, the `fedora-distrobox-quadlet.container` in `toolboxes` repo pulls from `ublue-os/fedora-toolbox:latest`. 
- I assume intended UX is that `ujust distrobox-assemble fedora` also enables quadlet functionality.

# Context
I have used `bluefin-dx-nvidia` for a while but have largely stuck to vanilla silverblue workflows until today, where I have been reading through the documentation and learning the intended workflows.

I was investigating why the "default key bindings" for Ptyxis was not working for me, and learned about quadlets, which I believe my system does not have set up, as `~/.config/containers/systemd` did not exist.

# Details
`rpm-ostree status -v`

```
● ostree-image-signed:docker://ghcr.io/ublue-os/bluefin-dx-nvidia:gts (index: 1)
                   Digest: sha256:e47d1b59d6f6c3ddd6ee2619c075d2a0ce6384bfae105ff5e1bfa7ec629cc93d
                  Version: 39.20240425.0 (2024-04-25T16:54:16Z)
               BaseCommit: 01d8bba833d5e5a5309df5ff98f7482b0929ab59a0c07aa399b0871aec3ffa10
                   Commit: 03fa10fa98bd017ba1e5c9370c9948e5bbcbcc7614bea51f6d74523ec89e75ac
                           ├─ code (2024-04-25T10:17:12Z)
                           ├─ copr:copr.fedorainfracloud.org:phracek:PyCharm (2024-03-18T11:54:48Z)
                           ├─ copr:copr.fedorainfracloud.org:ublue-os:akmods (2024-04-24T03:37:40Z)
                           ├─ fedora (2023-11-01T00:12:39Z)
                           ├─ keybase (2024-03-06T19:50:12Z)
                           ├─ rpmfusion-free (2023-11-04T16:49:08Z)
                           ├─ rpmfusion-free-updates (2024-04-24T11:17:46Z)
                           ├─ rpmfusion-nonfree (2023-11-04T17:26:32Z)
                           ├─ rpmfusion-nonfree-nvidia-driver (2024-04-24T10:49:24Z)
                           ├─ rpmfusion-nonfree-steam (2024-04-20T13:10:44Z)
                           ├─ rpmfusion-nonfree-updates (2024-04-24T11:35:33Z)
                           ├─ updates (2024-04-25T01:08:10Z)
                           └─ updates-archive (2024-04-25T01:48:26Z)
                StateRoot: fedora
          LayeredPackages: lzip printer-driver-brlaser python3.10 waydroid
            LocalPackages: keybase-6.0.2.20220610191041.a459abf326-1.x86_64 vktablet-1.2.4-10.x86_64
             InitramfsEtc: /etc/vconsole.conf

```
