### PR TITLE
fix(just): make toggle-updates check if ublue-update is installed

### DIFF
--- a/build/ublue-os-just/10-update.just
+++ b/build/ublue-os-just/10-update.just
@@ -88,9 +88,9 @@ toggle-updates ACTION="prompt":
     #!/usr/bin/bash
     source /usr/lib/ujust/ujust.sh
     CURRENT_STATE="Disabled"
-    if systemctl is-enabled ublue-update.timer 2> /dev/null | grep -q enabled; then
+    if systemctl -q is-enabled ublue-update.timer; then
       CURRENT_STATE="Enabled"
-    elif systemctl is-enabled rpm-ostreed-automatic.timer 2> /dev/null | grep -q enabled; then
+    elif systemctl -q is-enabled rpm-ostreed-automatic.timer; then
       CURRENT_STATE="Enabled"
     fi
     OPTION={{ ACTION }}

--- a/build/ublue-os-just/10-update.just
+++ b/build/ublue-os-just/10-update.just
@@ -88,7 +88,9 @@ toggle-updates ACTION="prompt":
     #!/usr/bin/bash
     source /usr/lib/ujust/ujust.sh
     CURRENT_STATE="Disabled"
-    if systemctl is-enabled ublue-update.timer | grep -q enabled; then
+    if systemctl is-enabled ublue-update.timer 2> /dev/null | grep -q enabled; then
+      CURRENT_STATE="Enabled"
+    elif systemctl is-enabled rpm-ostreed-automatic.timer 2> /dev/null | grep -q enabled; then
       CURRENT_STATE="Enabled"
     fi
     OPTION={{ ACTION }}
@@ -104,15 +106,19 @@ toggle-updates ACTION="prompt":
       exit 0
     fi
     if [ "${OPTION,,}" == "enable" ]; then
-      sudo systemctl enable ublue-update.timer
-      if systemctl is-enabled flatpak-system-update.timer | grep -q disabled; then
+      if systemctl is-enabled ublue-update.timer 2> /dev/null | grep -q not-found; then
         sudo systemctl enable --now flatpak-system-update.timer rpm-ostreed-automatic.timer
         systemctl enable --now --user flatpak-user-update.timer
-      fi
-    elif [ "${OPTION,,}" == "disable" ]; then
-      sudo systemctl disable ublue-update.timer
-      if systemctl is-enabled flatpak-system-update.timer | grep -q enabled; then
+      else
+        sudo systemctl enable ublue-update.timer
         sudo systemctl disable --now flatpak-system-update.timer rpm-ostreed-automatic.timer
         systemctl disable --now --user flatpak-user-update.timer
+      fi
+    elif [ "${OPTION,,}" == "disable" ]; then
+      if systemctl is-enabled ublue-update.timer 2> /dev/null | grep -q not-found; then
+        sudo systemctl disable --now flatpak-system-update.timer rpm-ostreed-automatic.timer
+        systemctl disable --now --user flatpak-user-update.timer
+      else
+        sudo systemctl disable ublue-update.timer
       fi
     fi

--- a/build/ublue-os-just/ublue-os-just.spec
+++ b/build/ublue-os-just/ublue-os-just.spec
@@ -1,7 +1,7 @@
 Name:           ublue-os-just
 Packager:       ublue-os
 Vendor:         ublue-os
-Version:        0.34
+Version:        0.35
 Release:        1%{?dist}
 Summary:        ublue-os just integration
 License:        MIT
@@ -109,6 +109,9 @@ just --completions bash | sed -E 's/([\(_" ])just/\1ujust/g' > %{_datadir}/bash-
 chmod 644 %{_datadir}/bash-completion/completions/ujust
 
 %changelog
+* Fri May 31 2024 HikariKnight <2557889+HikariKnight@users.noreply.github.com> - 0.35
+- Make toggle-updates smarter and detect if ublue-update is installed
+
 * Sat May 18 2024 m2Giles <69128853+m2Giles@users.noreply.github.com> - 0.34
 - Fix missing sourcefile for just split out
 


### PR DESCRIPTION
It will now toggle the auto update services relevant for the system depending on ublue-update being present or not.
I was originally under the impression that ublue-update was present in main 😅 this is fixed now (and also accounts for people adding ublue-update to their custom main images)