### PR TITLE
default to separate Distrobox home directories

### DIFF
--- a/files/etc/distrobox/distrobox.conf
+++ b/files/etc/distrobox/distrobox.conf
@@ -1,0 +1,2 @@
+DBX_CONTAINER_HOME_PREFIX=$HOME/distrobox
+container_image_default="ghcr.io/ublue-os/fedora-distrobox:latest"


### PR DESCRIPTION
## Issues
https://github.com/89luca89/distrobox/issues/1304

## Idea
Distrobox supports a well working config to automatically create a separate HOME directory for all boxes.

When entering the box, your directory will not change. But with `cd ~ && echo $PWD` you see that your home is different, and all the dotfiles are now separate and clean.
 
## Prevented issue
This is crucial to prevent messups between dotfiles. If users run different operating systems in the same HOME, this will cause breakages over time. `/var` is mutable, dotfiles are messy and scattered all around. This is a complete horror scenario and nobody seems to care currently.

Doing this is an easy and elegant fix.

## Testing
I use this config and tested it. Without adding any arguments, every newly created Distrobox will have a separated HOME directory in `~/distrobox/BOXNAME`. It works so well I have no idea why this is not the default. So I request this in one of the most used downstream configurations.

Using linking or copying you can move the dotfiles to that directory.

```fish
# nerdfonts required

~ ❯❯❯ cd ~/distrobox/
~/distrobox ❯❯❯ ls
 CentOS   Fedora
# empty "CentOS" directory created
~/distrobox ❯❯❯ #after entering the new CentOS box
~/distrobox ❯❯❯ ls
 CentOS   Fedora
# "CentOS" directory now populated with dotfiles
~/distrobox ❯❯❯ cd CentOS/
~/distrobox/CentOS ❯❯❯ ls -a
 .   ..  󱆃 .bash_logout  󱆃 .bash_profile  󱆃 .bashrc
```

## Scope
This will only affect the creation of new boxes, current boxes will not be modified.

## further ideas
A command to modify existing boxes, to use a separate home could be added to `just`. But this would either make them lose all their configs, or copy all the dotfiles from the userhome, which may not be needed.

Also, SELinux Confined Users will get interesting, here a `restorecon` may be needed, to label the `~/distrobox` directory exactly like home.