### PR TITLE
feat: Add arch amdgpupro image to distrobox.ini manifest

### DIFF
--- a/build/ublue-os-just/etc-distrobox/apps.ini
+++ b/build/ublue-os-just/etc-distrobox/apps.ini
@@ -18,3 +18,4 @@ image=ghcr.io/ublue-os/obs-studio-portable
 nvidia=true
 exported_apps=obs
 entry=false
+pull=true

--- a/build/ublue-os-just/etc-distrobox/distrobox.ini
+++ b/build/ublue-os-just/etc-distrobox/distrobox.ini
@@ -7,6 +7,10 @@
 image=ghcr.io/ublue-os/arch-distrobox:latest
 nvidia=true
 
+[arch-amdgpupro]
+image=ghcr.io/ublue-os/arch-distrobox-amdgpupro:latest
+nvidia=false
+
 [bluefin-cli]
 image=ghcr.io/ublue-os/bluefin-cli
 nvidia=true

--- a/build/ublue-os-just/etc-distrobox/distrobox.ini
+++ b/build/ublue-os-just/etc-distrobox/distrobox.ini
@@ -6,43 +6,54 @@
 [arch]
 image=ghcr.io/ublue-os/arch-distrobox:latest
 nvidia=true
+pull=true
 
 [arch-amdgpupro]
 image=ghcr.io/ublue-os/arch-distrobox-amdgpupro:latest
 nvidia=false
+pull=true
 
 [bluefin-cli]
 image=ghcr.io/ublue-os/bluefin-cli
 nvidia=true
+pull=true
 
 [debian]
 image=quay.io/toolbx-images/debian-toolbox:unstable
 nvidia=true
+pull=true
 
 [fedora]
 image=ghcr.io/ublue-os/fedora-distrobox:latest
 nvidia=true
+pull=true
 
 [opensuse]
 image=quay.io/toolbx-images/opensuse-toolbox:tumbleweed
 nvidia=true
+pull=true
 
 [ubuntu]
 image=ghcr.io/ublue-os/ubuntu-toolbox:latest
 nvidia=true
+pull=true
 
 [alma]
 image=quay.io/toolbx-images/almalinux-toolbox:latest
 nvidia=true
+pull=true
 
 [centos]
 image=quay.io/toolbx-images/centos-toolbox:latest
 nvidia=true
+pull=true
 
 [wolfi]
 image=ghcr.io/ublue-os/wolfi-toolbox
 nvidia=true
+pull=true
 
 [wolfi-dx]
 image=ghcr.io/ublue-os/wolfi-dx-toolbox
 nvidia=true
+pull=true


### PR DESCRIPTION
I recently was made aware of this image's existence, figured it should be added to the distrobox ini manifest.