### PR TITLE
feat: add tpm/fidopkcs11 LUKS unlock config to dracut

### DIFF
--- a/build/ublue-os-luks/90-ublue-luks.conf
+++ b/build/ublue-os-luks/90-ublue-luks.conf
@@ -1,0 +1,1 @@
+add_dracutmodules+=" fido2 tpm2-tss pkcs11 pcsc "

--- a/build/ublue-os-luks/build.sh
+++ b/build/ublue-os-luks/build.sh
@@ -7,6 +7,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 mkdir -p /tmp/ublue-os/rpmbuild/SOURCES
 
 cp ${SCRIPT_DIR}/luks* /tmp/ublue-os/rpmbuild/SOURCES
+cp ${SCRIPT_DIR}/90-ublue-luks.conf /tmp/ublue-os/rpmbuild/SOURCES
 
 rpmbuild -ba \
     --define '_topdir /tmp/ublue-os/rpmbuild' \

--- a/build/ublue-os-luks/ublue-os-luks.spec
+++ b/build/ublue-os-luks/ublue-os-luks.spec
@@ -1,7 +1,7 @@
 Name:           ublue-os-luks
 Packager:       ublue-os
 Vendor:         ublue-os
-Version:        0.1
+Version:        0.2
 Release:        1%{?dist}
 Summary:        ublue-os scripts for simplified LUKS usage
 License:        MIT
@@ -11,9 +11,10 @@ BuildArch:      noarch
 
 Source0:        luks-disable-tpm2-autounlock
 Source1:        luks-enable-tpm2-autounlock
+Source2:        90-ublue-luks.conf
 
 %description
-Adds scripts to simplify LUKS autounlock with TPM
+Adds scripts and dracut config to simplify LUKS autounlock
 
 %prep
 %setup -q -c -T
@@ -22,12 +23,17 @@ Adds scripts to simplify LUKS autounlock with TPM
 
 install -Dm755 %{SOURCE0}  %{buildroot}%{_libexecdir}/luks-disable-tpm2-autounlock
 install -Dm755 %{SOURCE1}  %{buildroot}%{_libexecdir}/luks-enable-tpm2-autounlock
+install -Dm644 %{SOURCE2}  %{buildroot}/%{_exec_prefix}/lib/dracut/dracut.conf.d/90-ublue-luks.conf
 
 %files
 %attr(0755,root,root) %{_libexecdir}/luks-disable-tpm2-autounlock
 %attr(0755,root,root) %{_libexecdir}/luks-enable-tpm2-autounlock
+%attr(0644,root,root) %{_exec_prefix}/lib/dracut/dracut.conf.d/90-ublue-luks.conf
 
 %changelog
-* Mon Apr 30 2024 Benjamin Sherman <benjamin@holyarmy.org> - 0.1
+* Sat Jun 29 2024 Benjamin Sherman <benjamin@holyarmy.org> - 0.2
+- Add tpm, fido2, pkcs11 to dracut config enabling initramfs LUKS unlock options
+
+* Tue Apr 30 2024 Benjamin Sherman <benjamin@holyarmy.org> - 0.1
 - Add tpm2 autounlock enable/disable scripts
 - Original source: https://github.com/bsherman/ublue-custom/


### PR DESCRIPTION
This enables any install to regenerate initramfs and automatically pickup these options for auto LUKS unlock on boot.

Closes: ublue-os/main#593
