### PR TITLE
feat: Add ability to handle multiple encrypted disks with luks-tpm.

### DIFF
--- a/build/ublue-os-luks/luks-disable-tpm2-autounlock
+++ b/build/ublue-os-luks/luks-disable-tpm2-autounlock
@@ -29,26 +29,28 @@ if ! grep -q "${RD_LUKS_UUID}" <<< "$(lsblk)" ; then
   printf "Exiting...\n"
   exit 1
 fi
-
+DISKS=(${RD_LUKS_UUID})
+CRYPT_DISKS=()
 # Cut off the luks-
 LUKS_PREFIX="luks-"
-if grep -q ^${LUKS_PREFIX} <<< "${RD_LUKS_UUID}"; then
-  DISK_UUID=${RD_LUKS_UUID#"$LUKS_PREFIX"}
-else
-  echo "LUKS UUID format mismatch."
-  echo "Exiting..."
-  exit 1
-fi
-
-# Specify Crypt Disk by-uuid
-CRYPT_DISK="/dev/disk/by-uuid/$DISK_UUID"
+for disk in ${DISKS[@]}; do
+	if grep -q ^${LUKS_PREFIX} <<< "${disk}"; then
+		CRYPT_DISKS+=("/dev/disk/by-uuid/"${disk#"$LUKS_PREFIX"})
+	else
+	  echo "LUKS UUID format mismatch."
+	  echo "Exiting..."
+	  exit 1
+	fi
+done
 
 # Check to make sure crypt disk exists
-if [[ ! -L "$CRYPT_DISK" ]]; then
-  printf "LUKS device not listed in block devices.\n"
-  printf "Exiting...\n"
-  exit 1
-fi
+for disk in ${CRYPT_DISKS[@]}; do
+	if [[ ! -L "$disk" ]]; then
+	  printf "LUKS device $disk not listed in block devices.\n"
+	  printf "Exiting...\n"
+	  exit 1
+	fi
+done
 
 ## Restore the crypttab
 cp -a /etc/crypttab /etc/crypttab.working-before-disable-tpm2
@@ -58,12 +60,15 @@ if [ -f /etc/crypttab.known-good ]; then
 fi
 
 ## Wipe luks slot
-if cryptsetup luksDump "$CRYPT_DISK" | grep systemd-tpm2 > /dev/null; then
-  echo "Wiping systemd-tpm2 from LUKS on $CRYPT_DISK"
-  systemd-cryptenroll --wipe-slot=tpm2 "$CRYPT_DISK"
-else
-  echo "No systemd-tpm2 found in LUKS to wipe"
-fi
+for disk in ${CRYPT_DISKS[@]}; do
+  cryptsetup luksDump $disk | grep systemd-tpm2 > /dev/null
+  if [ 0 -eq $? ]; then
+    echo "Wiping systemd-tpm2 from LUKS on $disk"
+    systemd-cryptenroll --wipe-slot=tpm2 $disk
+  else
+    echo "No systemd-tpm2 found in LUKS to wipe"
+  fi
+done
 
 ## Disable initramfs
 if rpm-ostree initramfs | grep tpm2 > /dev/null; then

--- a/build/ublue-os-luks/luks-enable-tpm2-autounlock
+++ b/build/ublue-os-luks/luks-enable-tpm2-autounlock
@@ -1,5 +1,5 @@
 #!/bin/bash
-## setup auto-unlock LUKS2 encrypted root on Fedora/Silverblue/maybe others
+## enable auto-unlock LUKS2 encrypted root on Fedora/Silverblue/maybe others
 set -eou pipefail
 
 [ "$UID" -eq 0 ] || { echo "This script must be run as root."; exit 1;}
@@ -33,38 +33,51 @@ if ! grep -q "${RD_LUKS_UUID}" <<< "$(lsblk)" ; then
   exit 1
 fi
 
+DISKS=(${RD_LUKS_UUID})
+CRYPT_DISKS=()
 # Cut off the luks-
 LUKS_PREFIX="luks-"
-if grep -q ^${LUKS_PREFIX} <<< "${RD_LUKS_UUID}"; then
-  DISK_UUID=${RD_LUKS_UUID#"$LUKS_PREFIX"}
-else
-  echo "LUKS UUID format mismatch."
-  echo "Exiting..."
-  exit 1
-fi
-
-# Specify Crypt Disk by-uuid
-CRYPT_DISK="/dev/disk/by-uuid/$DISK_UUID"
+for disk in ${DISKS[@]}; do
+	if grep -q ^${LUKS_PREFIX} <<< "${disk}"; then
+		CRYPT_DISKS+=("/dev/disk/by-uuid/"${disk#"$LUKS_PREFIX"})
+	else
+	  echo "LUKS UUID format mismatch for disk $disk."
+	  echo "Exiting..."
+	  exit 1
+	fi
+done
 
 # Check to make sure crypt disk exists
-if [[ ! -L "$CRYPT_DISK" ]]; then
-  printf "LUKS device not listed in block devices.\n"
-  printf "Exiting...\n"
-  exit 1
-fi
+for disk in ${CRYPT_DISKS[@]}; do
+	if [[ ! -L "$disk" ]]; then
+	  printf "LUKS device $disk not listed in block devices.\n"
+	  printf "Exiting...\n"
+	  exit 1
+	fi
+done
 
-if cryptsetup luksDump "$CRYPT_DISK" | grep systemd-tpm2 > /dev/null; then
-  KEYSLOT=$(cryptsetup luksDump "$CRYPT_DISK"|grep -A29 systemd-tpm2|grep Keyslot|awk '{print $2}')
-  echo "TPM2 already present in LUKS Keyslot $KEYSLOT of $CRYPT_DISK."
-  echo "Remove the existing TPM2 enrollment with ujust remove-luks-tpm2-autounlock"
-  echo "Exiting..."
-  [[ "$0" = "${BASH_SOURCE[0]}" ]] && exit 1 || return 1
-fi
+
+for disk in ${CRYPT_DISKS[@]}; do
+  cryptsetup luksDump $disk | grep systemd-tpm2 > /dev/null
+  if cryptsetup luksDump "$disk" | grep systemd-tpm2 > /dev/null; then
+    KEYSLOT=$(cryptsetup luksDump "$disk"|grep -A29 systemd-tpm2|grep Keyslot|awk '{print $2}')
+    echo "TPM2 already present in LUKS Keyslot $KEYSLOT of $disk."
+    echo "Remove the existing TPM2 enrollment with ujust remove-luks-tpm2-autounlock"
+    echo "Exiting..."
+    [[ "$0" = "${BASH_SOURCE[0]}" ]] && exit 1 || return 1
+  fi
+done
+
+## modify the crypttab
+sed -i "s/discard/discard,tpm2-device=auto/" /etc/crypttab
 
 ## Run crypt enroll
 echo "Enrolling TPM2 unlock requires your existing LUKS2 unlock password"
-systemd-cryptenroll --tpm2-device=auto --tpm2-pcrs=7 "$CRYPT_DISK"
-
+echo
+for disk in ${CRYPT_DISKS[@]}; do
+  echo "Enrolling TPM2 unlock for $disk"
+  systemd-cryptenroll --tpm2-device=auto --tpm2-pcrs=7 $disk
+done
 
 if lsinitrd 2>&1 | grep -q tpm2-tss > /dev/null; then
   ## add tpm2-tss to initramfs


### PR DESCRIPTION
The current scripts assumes that system only spans
over a single encrypted drive. This patch adds
ability to add tpm key slots to multiple encrypted drives and also remove them.

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.
I have tested the scripts on my system.
![Screenshot from 2024-06-30 23-10-01](https://github.com/ublue-os/config/assets/55192001/895cd35c-957d-4364-bf5a-cc285b206d84)

![Screenshot from 2024-06-30 23-09-29](https://github.com/ublue-os/config/assets/55192001/65294bdd-459a-4f34-bdd6-a83fcaf5d776)
