### PR TITLE
chore: add fix-key-and-update.sh script to resolve cosign pub key issues

### DIFF
--- a/scripts/fix-key-and-update.sh
+++ b/scripts/fix-key-and-update.sh
@@ -24,6 +24,3 @@ sed -i.bak "s#/usr/etc/pki/containers/ublue-os.pub#/etc/pki/containers/ublue-os.
 # Update system, respecting new public signing key.
 echo "Updating the system..."
 rpm-ostree update
-
-# Clean up
-rm /etc/containers/policy.json.bak

--- a/scripts/fix-key-and-update.sh
+++ b/scripts/fix-key-and-update.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/bash
+#
+# This is a tool to provide easy change to the new Universal Blue image signing key, updated July 2, 2024.
+#
+# Note: this is required for upgrades to images published after July 1, 2024, and will prevent downgrading
+# to images published before July 2, 2024.
+#
+set -eux
+
+# Require root privileges
+if [ "$EUID" -ne 0 ]; then
+  echo "Please run as root"
+  exit 1
+fi
+
+# Fetch the new public key from ublue-os's github repo, updating the local copy.
+echo "Fetching the new public key from ublue-os's github repo..."
+curl https://raw.githubusercontent.com/ublue-os/main/main/cosign.pub > /etc/pki/containers/ublue-os.pub
+
+# Ensure the path to the public key matches the local copy location.
+echo "Updating the path to the public key in the container policy..."
+sed -i.bak "s#/usr/etc/pki/containers/ublue-os.pub#/etc/pki/containers/ublue-os.pub#" /etc/containers/policy.json
+
+# Update system, respecting new public signing key.
+echo "Updating the system..."
+rpm-ostree update
+
+# Clean up
+rm /etc/containers/policy.json.bak

--- a/scripts/fix-key-and-update.sh
+++ b/scripts/fix-key-and-update.sh
@@ -5,7 +5,7 @@
 # Note: this is required for upgrades to images published after July 1, 2024, and will prevent downgrading
 # to images published before July 2, 2024.
 #
-set -eux
+set -eu
 
 # Require root privileges
 if [ "$EUID" -ne 0 ]; then


### PR DESCRIPTION
## Thank you for contributing to the Universal Blue project!

Adds a script which can be executed by users who are on an image signed by an older cosign key pair.