### PR TITLE
chore(fix-key-and-update): Remove invalid ".bak" passed to sed

### DIFF
--- a/scripts/fix-key-and-update.sh
+++ b/scripts/fix-key-and-update.sh
@@ -19,7 +19,7 @@ curl https://raw.githubusercontent.com/ublue-os/main/main/cosign.pub > /etc/pki/
 
 # Ensure the path to the public key matches the local copy location.
 echo "Updating the path to the public key in the container policy..."
-sed -i.bak "s#/usr/etc/pki/containers/ublue-os.pub#/etc/pki/containers/ublue-os.pub#" /etc/containers/policy.json
+sed -i "s#/usr/etc/pki/containers/ublue-os.pub#/etc/pki/containers/ublue-os.pub#" /etc/containers/policy.json
 
 # Update system, respecting new public signing key.
 echo "Updating the system..."


### PR DESCRIPTION
Doesn't actually appear to error out when running but the syntax is wrong