### PR TITLE
fix: ujust device-info script

### DIFF
--- a/build/ublue-os-just/00-default.just
+++ b/build/ublue-os-just/00-default.just
@@ -116,8 +116,7 @@ check-local-overrides:
 # Gather device info to a pastebin
 device-info:
     #!/usr/bin/bash
-    echo "Gathering device info..."
-    fpaste <(rpm-ostree status) <(fpaste --sysinfo --printonly) <<(flatpak list --columns=application,version,options)
+    fpaste <(rpm-ostree status) <(fpaste --sysinfo --printonly) <(flatpak list --columns=application,version,options)
 
 # Measure Idle Power Draw
 check-idle-power-draw:


### PR DESCRIPTION
`ujust device-info` seems to be broken since this commit: [feat(just): add flatpak list to device-info](https://github.com/ublue-os/config/commit/581c0ed81bc88a1384d76dd3918b9af73e3ee503)

```
❯ ujust device-info
Gathering device info...
/run/user/1000/just/just-ZKOZ4x/device-info: line 120: syntax error near unexpected token `('
/run/user/1000/just/just-ZKOZ4x/device-info: line 120: `fpaste <(rpm-ostree status) <(fpaste --sysinfo --printonly) <<(flatpak list --columns=application,version,options)'
error: Recipe `device-info` failed with exit code 2
```

Even tho manually running the script works fine, I think the `<<` part is what's breaking this, even tho running the script manually from terminal works just fine:
```
❯ fpaste <(rpm-ostree status) <(fpaste --sysinfo --printonly) <<(flatpak list --columns=application,version,options)
Gathering system info ...............................Uploading (35.9KiB)...
https://paste.centos.org/view/52676bc3
```

Note that the changed script works too:
```
❯ fpaste <(rpm-ostree status) <(fpaste --sysinfo --printonly) <(flatpak list --columns=application,version,options)
Gathering system info ...............................Uploading (44.1KiB)...
https://paste.centos.org/view/ffd40d2d
```

If this still breaks, I'd propose using something like this instead:
```
# Gather device info to a pastebin
device-info:
    #!/usr/bin/bash
    echo "$(rpm-ostree status) \n $(fpaste --sysinfo --printonly) \n $(flatpak list --columns=application,version,options) \n" | fpaste
```

*Note* that `echo "Gathering device info..."` is not needed because a similar message is output from `fpaste --sysinfo --printonly`