### PR TITLE
revert: "feat: set Recommends=false by default to minimize local layer size"

### DIFF
--- a/files/etc/rpm-ostreed.conf
+++ b/files/etc/rpm-ostreed.conf
@@ -5,4 +5,3 @@
 [Daemon]
 AutomaticUpdatePolicy=stage
 #IdleExitTimeout=60
-Recommends=false


### PR DESCRIPTION
This causes issues with people in chat "I added this package and it didn't bring libvirt" etc.

In hindsight let's back this out, there's no reason to deviate from fedora on this one.