### PR TITLE
feat(revert): "add udev rules for linksys ae1200 usb wifi dongle (#214)"

### DIFF
--- a/files/etc/udev/rules.d/30-linksys-ae1200.rules
+++ b/files/etc/udev/rules.d/30-linksys-ae1200.rules
@@ -1,3 +1,0 @@
-ACTION=="add",ATTRS{idVendor}=="13b1",ATTRS{idProduct}=="0bdc",
-RUN+="/sbin/modprobe brcmfmac"
-RUN+="/bin/sh -c 'echo 13b1 0bdc > /sys/bus/usb/drivers/brcmfmac/new_id'"


### PR DESCRIPTION
This reverts commit dbf4dd3485de680528a6b200d344072d129f2304.

For justification please see:
https://github.com/ublue-os/main/issues/644