### PR TITLE
feat(just): Use `run0` instead of `sudo` in scripts

### DIFF
--- a/build/ublue-os-just/00-default.just
+++ b/build/ublue-os-just/00-default.just
@@ -14,26 +14,25 @@ bios:
 
 # Show all messages from this boot
 logs-this-boot:
-    sudo journalctl -b 0
+    run0 journalctl -b 0
 
 # Show all messages from last boot
 logs-last-boot:
-    sudo journalctl -b -1
+    run0 journalctl -b -1
 
 # Regenerate GRUB config, useful in dual-boot scenarios where a second operating system isn't listed
 regenerate-grub:
     #!/usr/bin/bash
     if [ -d /sys/firmware/efi ]; then
-      sudo grub2-mkconfig -o /etc/grub2-efi.cfg
+      run0 grub2-mkconfig -o /etc/grub2-efi.cfg
     else
-      sudo grub2-mkconfig -o /etc/grub2.cfg
+      run0 grub2-mkconfig -o /etc/grub2.cfg
     fi
 
 # Enroll Nvidia driver & KMOD signing key for secure boot - Enter password "universalblue" if prompted
 enroll-secure-boot-key:
     echo 'Enter password "universalblue" if prompted after your user password.'
-    sudo mokutil --timeout -1
-    sudo mokutil --import /etc/pki/akmods/certs/akmods-ublue.der
+    run0 bash -c "mokutil --timeout -1; mokutil --import /etc/pki/akmods/certs/akmods-ublue.der"
     echo 'When you reboot your computer, follow the instructions to start MOK util'
     echo 'by pressing a key, then enroll the secure boot key and enter "universalblue" as the password'
 
@@ -106,4 +105,4 @@ device-info:
 # Measure Idle Power Draw
 check-idle-power-draw:
     #!/usr/bin/bash
-    sudo powerstat -a -r
+    run0 powerstat -a -r

--- a/build/ublue-os-just/00-default.just
+++ b/build/ublue-os-just/00-default.just
@@ -14,25 +14,25 @@ bios:
 
 # Show all messages from this boot
 logs-this-boot:
-    run0 journalctl -b 0
+    run-as-root journalctl -b 0
 
 # Show all messages from last boot
 logs-last-boot:
-    run0 journalctl -b -1
+    run-as-root journalctl -b -1
 
 # Regenerate GRUB config, useful in dual-boot scenarios where a second operating system isn't listed
 regenerate-grub:
     #!/usr/bin/bash
     if [ -d /sys/firmware/efi ]; then
-      run0 grub2-mkconfig -o /etc/grub2-efi.cfg
+      run-as-root grub2-mkconfig -o /etc/grub2-efi.cfg
     else
-      run0 grub2-mkconfig -o /etc/grub2.cfg
+      run-as-root grub2-mkconfig -o /etc/grub2.cfg
     fi
 
 # Enroll Nvidia driver & KMOD signing key for secure boot - Enter password "universalblue" if prompted
 enroll-secure-boot-key:
     echo 'Enter password "universalblue" if prompted after your user password.'
-    run0 bash -c "mokutil --timeout -1; mokutil --import /etc/pki/akmods/certs/akmods-ublue.der"
+    run-as-root bash -c "mokutil --timeout -1; mokutil --import /etc/pki/akmods/certs/akmods-ublue.der"
     echo 'When you reboot your computer, follow the instructions to start MOK util'
     echo 'by pressing a key, then enroll the secure boot key and enter "universalblue" as the password'
 
@@ -105,4 +105,4 @@ device-info:
 # Measure Idle Power Draw
 check-idle-power-draw:
     #!/usr/bin/bash
-    run0 powerstat -a -r
+    run-as-root powerstat -a -r

--- a/build/ublue-os-just/10-update.just
+++ b/build/ublue-os-just/10-update.just
@@ -8,7 +8,7 @@ update VERB_LEVEL="full":
     if systemctl is-enabled ublue-update.timer | grep -q enabled;
     then
       echo "Starting the ublue-update service"
-      sudo systemctl start ublue-update.service
+      run0 systemctl start ublue-update.service
     else
       if [ {{ VERB_LEVEL }} = "help" ]; then
           echo "Usage: just update <level>"
@@ -107,18 +107,17 @@ toggle-updates ACTION="prompt":
     fi
     if [ "${OPTION,,}" == "enable" ]; then
       if systemctl is-enabled ublue-update.timer 2> /dev/null | grep -q not-found; then
-        sudo systemctl enable --now flatpak-system-update.timer rpm-ostreed-automatic.timer
+        run0 systemctl enable --now flatpak-system-update.timer rpm-ostreed-automatic.timer
         systemctl enable --now --user flatpak-user-update.timer
       else
-        sudo systemctl enable ublue-update.timer
-        sudo systemctl disable --now flatpak-system-update.timer rpm-ostreed-automatic.timer
+        run0 bash -c "systemctl enable ublue-update.timer; systemctl disable --now flatpak-system-update.timer rpm-ostreed-automatic.timer"
         systemctl disable --now --user flatpak-user-update.timer
       fi
     elif [ "${OPTION,,}" == "disable" ]; then
       if systemctl is-enabled ublue-update.timer 2> /dev/null | grep -q not-found; then
-        sudo systemctl disable --now flatpak-system-update.timer rpm-ostreed-automatic.timer
+        run0 systemctl disable --now flatpak-system-update.timer rpm-ostreed-automatic.timer
         systemctl disable --now --user flatpak-user-update.timer
       else
-        sudo systemctl disable ublue-update.timer
+        run0 systemctl disable ublue-update.timer
       fi
     fi

--- a/build/ublue-os-just/10-update.just
+++ b/build/ublue-os-just/10-update.just
@@ -8,7 +8,7 @@ update VERB_LEVEL="full":
     if systemctl is-enabled ublue-update.timer | grep -q enabled;
     then
       echo "Starting the ublue-update service"
-      run0 systemctl start ublue-update.service
+      run-as-root systemctl start ublue-update.service
     else
       if [ {{ VERB_LEVEL }} = "help" ]; then
           echo "Usage: just update <level>"
@@ -107,17 +107,17 @@ toggle-updates ACTION="prompt":
     fi
     if [ "${OPTION,,}" == "enable" ]; then
       if systemctl is-enabled ublue-update.timer 2> /dev/null | grep -q not-found; then
-        run0 systemctl enable --now flatpak-system-update.timer rpm-ostreed-automatic.timer
+        run-as-root systemctl enable --now flatpak-system-update.timer rpm-ostreed-automatic.timer
         systemctl enable --now --user flatpak-user-update.timer
       else
-        run0 bash -c "systemctl enable ublue-update.timer; systemctl disable --now flatpak-system-update.timer rpm-ostreed-automatic.timer"
+        run-as-root bash -c "systemctl enable ublue-update.timer; systemctl disable --now flatpak-system-update.timer rpm-ostreed-automatic.timer"
         systemctl disable --now --user flatpak-user-update.timer
       fi
     elif [ "${OPTION,,}" == "disable" ]; then
       if systemctl is-enabled ublue-update.timer 2> /dev/null | grep -q not-found; then
-        run0 systemctl disable --now flatpak-system-update.timer rpm-ostreed-automatic.timer
+        run-as-root systemctl disable --now flatpak-system-update.timer rpm-ostreed-automatic.timer
         systemctl disable --now --user flatpak-user-update.timer
       else
-        run0 systemctl disable ublue-update.timer
+        run-as-root systemctl disable ublue-update.timer
       fi
     fi

--- a/build/ublue-os-just/15-luks.just
+++ b/build/ublue-os-just/15-luks.just
@@ -3,9 +3,9 @@
 # Enable automatic LUKS unlock via TPM
 setup-luks-tpm-unlock:
     #!/usr/bin/bash
-    run0 /usr/libexec/luks-enable-tpm2-autounlock
+    run-as-root /usr/libexec/luks-enable-tpm2-autounlock
 
 # Disable automatic LUKS unlock via TPM
 remove-luks-tpm-unlock:
     #!/usr/bin/bash
-    run0 /usr/libexec/luks-disable-tpm2-autounlock
+    run-as-root /usr/libexec/luks-disable-tpm2-autounlock

--- a/build/ublue-os-just/15-luks.just
+++ b/build/ublue-os-just/15-luks.just
@@ -3,9 +3,9 @@
 # Enable automatic LUKS unlock via TPM
 setup-luks-tpm-unlock:
     #!/usr/bin/bash
-    sudo /usr/libexec/luks-enable-tpm2-autounlock
+    run0 /usr/libexec/luks-enable-tpm2-autounlock
 
 # Disable automatic LUKS unlock via TPM
 remove-luks-tpm-unlock:
     #!/usr/bin/bash
-    sudo /usr/libexec/luks-disable-tpm2-autounlock
+    run0 /usr/libexec/luks-disable-tpm2-autounlock

--- a/build/ublue-os-just/40-nvidia.just
+++ b/build/ublue-os-just/40-nvidia.just
@@ -74,7 +74,7 @@ toggle-nvk:
 
 # Configure Nvidia Optimus
 configure-nvidia-optimus ACTION="prompt":
-    #!/usr/bin/pkexec /usr/bin/bash
+    #!/usr/bin/bash
     source /usr/lib/ujust/ujust.sh
     OPTION={{ ACTION }}
     if [ "$OPTION" == "prompt" ]; then
@@ -90,8 +90,7 @@ configure-nvidia-optimus ACTION="prompt":
     if [ "$OPTION" == "Set fine-grained dynamic power management" ] || [ "${OPTION,,}" == "power-management" ]; then
       if command -v nvidia-smi; then
         if [ ! -f /etc/modprobe.d/nvidia.conf ] || ! grep -qF "NVreg_DynamicPowerManagement" /etc/modprobe.d/nvidia.conf; then
-          echo "# https://download.nvidia.com/XFree86/Linux-x86_64/545.29.06/README/dynamicpowermanagement.html" >> /etc/modprobe.d/nvidia.conf
-          echo "options nvidia NVreg_DynamicPowerManagement=0x02" >> /etc/modprobe.d/nvidia.conf
+          run0 bash -c 'printf "# %s\n%s\n" "https://download.nvidia.com/XFree86/Linux-x86_64/545.29.06/README/dynamicpowermanagement.html" "options nvidia NVreg_DynamicPowerManagement=0x02" >> /etc/modprobe.d/nvidia.conf'
         else 
           echo 'Already applied fine-grained dynamic power management.'
         fi

--- a/build/ublue-os-just/40-nvidia.just
+++ b/build/ublue-os-just/40-nvidia.just
@@ -90,7 +90,7 @@ configure-nvidia-optimus ACTION="prompt":
     if [ "$OPTION" == "Set fine-grained dynamic power management" ] || [ "${OPTION,,}" == "power-management" ]; then
       if command -v nvidia-smi; then
         if [ ! -f /etc/modprobe.d/nvidia.conf ] || ! grep -qF "NVreg_DynamicPowerManagement" /etc/modprobe.d/nvidia.conf; then
-          run0 bash -c 'printf "# %s\n%s\n" "https://download.nvidia.com/XFree86/Linux-x86_64/545.29.06/README/dynamicpowermanagement.html" "options nvidia NVreg_DynamicPowerManagement=0x02" >> /etc/modprobe.d/nvidia.conf'
+          run-as-root bash -c 'printf "# %s\n%s\n" "https://download.nvidia.com/XFree86/Linux-x86_64/545.29.06/README/dynamicpowermanagement.html" "options nvidia NVreg_DynamicPowerManagement=0x02" >> /etc/modprobe.d/nvidia.conf'
         else 
           echo 'Already applied fine-grained dynamic power management.'
         fi

--- a/build/ublue-os-just/50-akmods.just
+++ b/build/ublue-os-just/50-akmods.just
@@ -20,11 +20,9 @@ configure-broadcom-wl ACTION="prompt":
       exit 0
     fi
     if [ "${OPTION,,}" == "enable" ]; then
-      sudo rm -f /etc/modprobe.d/broadcom-wl-blacklist.conf
-      sudo rm -f /etc/modprobe.d/default-disable-broadcom-wl.conf
+      run0 rm -f /etc/modprobe.d/broadcom-wl-blacklist.conf /etc/modprobe.d/default-disable-broadcom-wl.conf
       echo "${bold}Enabled${normal} Broadcom Wireless, please reboot for changes to take effect"
     elif [ "${OPTION,,}" == "disable" ]; then
-      sudo bash -c '> /etc/modules-load.d/broadcom-wl-blacklist.conf'
-      sudo bash -c 'echo "blacklist wl" > /etc/modules-load.d/default-disable-broadcom-wl.conf'
+      run0 bash -c '> /etc/modules-load.d/broadcom-wl-blacklist.conf; echo "blacklist wl" > /etc/modules-load.d/default-disable-broadcom-wl.conf'
       echo "${bold}Disabled${normal} Broadcom Wireless, please reboot for changes to take effect"
     fi

--- a/build/ublue-os-just/50-akmods.just
+++ b/build/ublue-os-just/50-akmods.just
@@ -20,9 +20,9 @@ configure-broadcom-wl ACTION="prompt":
       exit 0
     fi
     if [ "${OPTION,,}" == "enable" ]; then
-      run0 rm -f /etc/modprobe.d/broadcom-wl-blacklist.conf /etc/modprobe.d/default-disable-broadcom-wl.conf
+      run-as-root rm -f /etc/modprobe.d/broadcom-wl-blacklist.conf /etc/modprobe.d/default-disable-broadcom-wl.conf
       echo "${bold}Enabled${normal} Broadcom Wireless, please reboot for changes to take effect"
     elif [ "${OPTION,,}" == "disable" ]; then
-      run0 bash -c '> /etc/modules-load.d/broadcom-wl-blacklist.conf; echo "blacklist wl" > /etc/modules-load.d/default-disable-broadcom-wl.conf'
+      run-as-root bash -c '> /etc/modules-load.d/broadcom-wl-blacklist.conf; echo "blacklist wl" > /etc/modules-load.d/default-disable-broadcom-wl.conf'
       echo "${bold}Disabled${normal} Broadcom Wireless, please reboot for changes to take effect"
     fi

--- a/build/ublue-os-just/lib-ujust/librun0.sh
+++ b/build/ublue-os-just/lib-ujust/librun0.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/bash
+
+# Function to use run0 instead of sudo, if installed (since F41)
+# run0 is more secure than using sudo, so it's recommend to use it instead of sudo
+# The current caveat is that run0 always requires password authentication per root-call (--no-ask-password doesn't work at the moment)
+# so use it only for one-liner commands (bash -c can help here, with potential of less readable code)
+# See:
+# https://github.com/systemd/systemd/issues/33366
+# https://github.com/polkit-org/polkit/issues/472
+
+run0() {
+if command -v run0 &> /dev/null; then
+  run0 "${@}"
+else
+  sudo "${@}"
+fi  
+}

--- a/build/ublue-os-just/lib-ujust/librun0.sh
+++ b/build/ublue-os-just/lib-ujust/librun0.sh
@@ -10,7 +10,7 @@
 
 run0() {
 if command -v run0 &> /dev/null; then
-  run0 "${@}"
+  run0 --background="" "${@}"
 else
   sudo "${@}"
 fi  

--- a/build/ublue-os-just/lib-ujust/librunasroot.sh
+++ b/build/ublue-os-just/lib-ujust/librunasroot.sh
@@ -8,7 +8,7 @@
 # https://github.com/systemd/systemd/issues/33366
 # https://github.com/polkit-org/polkit/issues/472
 
-run0() {
+run-as-root() {
 if command -v run0 &> /dev/null; then
   run0 --background="" "${@}"
 else

--- a/build/ublue-os-just/lib-ujust/ujust.sh
+++ b/build/ublue-os-just/lib-ujust/ujust.sh
@@ -10,3 +10,5 @@ source /usr/lib/ujust/libfunctions.sh
 source /usr/lib/ujust/libdistrobox.sh
 # Import functionality related to toolbox
 source /usr/lib/ujust/libtoolbox.sh
+# Import functionality related to usage of run0
+source /usr/lib/ujust/librun0.sh

--- a/build/ublue-os-just/lib-ujust/ujust.sh
+++ b/build/ublue-os-just/lib-ujust/ujust.sh
@@ -11,4 +11,4 @@ source /usr/lib/ujust/libdistrobox.sh
 # Import functionality related to toolbox
 source /usr/lib/ujust/libtoolbox.sh
 # Import functionality related to usage of run0
-source /usr/lib/ujust/librun0.sh
+source /usr/lib/ujust/librunasroot.sh

--- a/build/ublue-os-just/ublue-os-just.spec
+++ b/build/ublue-os-just/ublue-os-just.spec
@@ -37,7 +37,7 @@ Source21:       toolbox.ini
 Source22:       31-toolbox.just
 Source23:       brew.sh
 Source24:       15-ublue-config.md
-Source25:       librun0.sh
+Source25:       librunasroot.sh
 
 %global sub_name %{lua:t=string.gsub(rpm.expand("%{NAME}"), "^ublue%-os%-", ""); print(t)}
 

--- a/build/ublue-os-just/ublue-os-just.spec
+++ b/build/ublue-os-just/ublue-os-just.spec
@@ -1,7 +1,7 @@
 Name:           ublue-os-just
 Packager:       ublue-os
 Vendor:         ublue-os
-Version:        0.36
+Version:        0.37
 Release:        1%{?dist}
 Summary:        ublue-os just integration
 License:        MIT
@@ -37,6 +37,7 @@ Source21:       toolbox.ini
 Source22:       31-toolbox.just
 Source23:       brew.sh
 Source24:       15-ublue-config.md
+Source25:       librun0.sh
 
 %global sub_name %{lua:t=string.gsub(rpm.expand("%{NAME}"), "^ublue%-os%-", ""); print(t)}
 
@@ -77,6 +78,7 @@ install -Dm644 %{SOURCE14} %{buildroot}/%{_exec_prefix}/lib/ujust
 install -Dm644 %{SOURCE15} %{buildroot}/%{_exec_prefix}/lib/ujust
 install -Dm644 %{SOURCE16} %{buildroot}/%{_exec_prefix}/lib/ujust
 install -Dm644 %{SOURCE20} %{buildroot}/%{_exec_prefix}/lib/ujust
+install -Dm644 %{SOURCE25} %{buildroot}/%{_exec_prefix}/lib/ujust
 
 # Add default manifest files for distrobox
 mkdir -p -m0755 %{buildroot}/%{_sysconfdir}/distrobox
@@ -108,6 +110,10 @@ just --completions bash | sed -E 's/([\(_" ])just/\1ujust/g' > %{_datadir}/bash-
 chmod 644 %{_datadir}/bash-completion/completions/ujust
 
 %changelog
+* Wed Oct 30 2024 Fifty Dinar <srbaizoki4@tuta.io> - 0.37
+- Add library for using `run0` if installed, with fallback to `sudo`
+- Switch from using `sudo` to more secure `run0` for root command calls
+
 * Fri Sep 20 2024 Kyle Gospodnetich <me@kylegospodneti.ch> - 0.36
 - Remove no longer needed brew commands, now on image
 


### PR DESCRIPTION
It is more secure than `sudo` & it uses native password dialog.

`run0` currently always asks for the password per root-call at the moment, so I modified the scripts which used `sudo` to initiate 1 call only. So user will only see 1 password prompt. This may make some scripts slightly less readable, but it's still easy to read imo.

I added `librunasroot`, which only uses `run0` if it's installed, while fallbacking to `sudo` if not. This makes sure that <=F40 images won't be affected badly with this change.

RPM is updated to reflect this change.