### PR TITLE
fix(just): Alias `just` to `ujust`, to avoid non-working `just` command

### DIFF
--- a/build/ublue-os-just/etc-profile.d/ublue-os-just.sh
+++ b/build/ublue-os-just/etc-profile.d/ublue-os-just.sh
@@ -17,3 +17,6 @@ if [ -f "${HOME}/.justfile" ]; then
     echo 'import "/usr/share/ublue-os/justfile"' | tee -a "${HOME}/.justfile"
   fi
 fi
+
+# Alias ujust to just, so using `just` command works
+alias just='ujust'

--- a/build/ublue-os-just/etc-profile.d/ublue-os-just.sh
+++ b/build/ublue-os-just/etc-profile.d/ublue-os-just.sh
@@ -19,4 +19,11 @@ if [ -f "${HOME}/.justfile" ]; then
 fi
 
 # Alias ujust to just, so using `just` command works
-alias just='ujust'
+just() {
+  if [ ${#} -eq 0 ]; then
+    ujust
+  else
+    just "${@}"
+  fi  
+}
+export -f just

--- a/build/ublue-os-just/ublue-os-just.spec
+++ b/build/ublue-os-just/ublue-os-just.spec
@@ -1,7 +1,7 @@
 Name:           ublue-os-just
 Packager:       ublue-os
 Vendor:         ublue-os
-Version:        0.36
+Version:        0.37
 Release:        1%{?dist}
 Summary:        ublue-os just integration
 License:        MIT
@@ -108,6 +108,9 @@ just --completions bash | sed -E 's/([\(_" ])just/\1ujust/g' > %{_datadir}/bash-
 chmod 644 %{_datadir}/bash-completion/completions/ujust
 
 %changelog
+* Fri Nov 01 2024 Fifty Dinar <srbaizoki4@tuta.io> - 0.37
+- Alias `just` to `ujust`, to avoid non-working `just` command
+
 * Fri Sep 20 2024 Kyle Gospodnetich <me@kylegospodneti.ch> - 0.36
 - Remove no longer needed brew commands, now on image
 


### PR DESCRIPTION
Useful for people who just type `just` instead of `ujust`.