### PR TITLE
fix: luks allow wipe for re-enroll and improve prompt/output

### DIFF
--- a/build/ublue-os-luks/luks-disable-tpm2-autounlock
+++ b/build/ublue-os-luks/luks-disable-tpm2-autounlock
@@ -6,7 +6,8 @@ set -euo pipefail
 
 echo "This script utilizes systemd-cryptenroll for removing tpm2 auto-unlock."
 echo "You can review systemd-cryptenroll's manpage for more information."
-read -p "This will modify your system and disable TPM2 auto-unlock of your LUKS partition! Are you sure you are good with this? " -n 1 -r
+echo "This will modify your system and disable TPM2 auto-unlock of your LUKS partition!"
+read -p "Are you sure are good with this and want to disable TPM2 auto-unlock? (y/N): " -n 1 -r
 echo
 if [[ ! $REPLY =~ ^[Yy]$ ]]; then
   [[ "$0" = "${BASH_SOURCE[0]}" ]] && exit 1 || return 1 # handle exits from shell or function but don't exit interactive shell

--- a/build/ublue-os-luks/luks-disable-tpm2-autounlock
+++ b/build/ublue-os-luks/luks-disable-tpm2-autounlock
@@ -78,4 +78,3 @@ else
 fi
 
 echo "TPM2 auto-unlock disabled..."
-echo "To reenroll TPM2 auto unlock please run ujust setup-luks-tpm-unlock..."

--- a/build/ublue-os-luks/luks-enable-tpm2-autounlock
+++ b/build/ublue-os-luks/luks-enable-tpm2-autounlock
@@ -14,7 +14,7 @@ echo "You can review systemd-cryptenroll's manpage for more information."
 echo "This script will modify your system."
 echo "It will enable TPM2 auto-unlock of your LUKS partition for your root device!"
 echo "It will bind to PCR 7 and 14 which is tied to your secureboot and moklist state."
-read -p "Are you sure are good with this and want to enable TPM2 auto-unlock? " -n 1 -r
+read -p "Are you sure are good with this and want to enable TPM2 auto-unlock? (y/N): " -n 1 -r
 echo
 if [[ ! $REPLY =~ ^[Yy]$ ]]; then
   [[ "$0" = "${BASH_SOURCE[0]}" ]] && exit 1 || return 1 # handle exits from shell or function but don't exit interactive shell
@@ -49,7 +49,7 @@ else
 fi
 
 SET_PIN_ARG=""
-read -p "Would you like to set a pin? (Y/n)" -n 1 -r
+read -p "Would you like to set a PIN? (y/N): " -n 1 -r
 echo
 if [[ $REPLY =~ ^[Yy]$ ]]; then
   SET_PIN_ARG=" --tpm2-with-pin=yes "
@@ -67,9 +67,17 @@ fi
 
 if cryptsetup luksDump "$CRYPT_DISK" | grep systemd-tpm2 > /dev/null; then
   KEYSLOT=$(cryptsetup luksDump "$CRYPT_DISK"|grep -A29 systemd-tpm2|grep Keyslot|awk '{print $2}')
-  echo "TPM2 already present in LUKS Keyslot $KEYSLOT of $CRYPT_DISK."
-  echo "Wiping systemd-tpm2 from LUKS Keyslot $KEYSLOT of $CRYPT_DISK."
-  systemd-cryptenroll --wipe-slot=$KEYSLOT "$CRYPT_DISK"
+  echo "TPM2 already present in LUKS keyslot $KEYSLOT of $CRYPT_DISK."
+  read -p "Wipe it and re-enroll? (y/N): " -n 1 -r
+  echo
+  if [[ $REPLY =~ ^[Yy]$ ]]; then
+    systemd-cryptenroll --wipe-slot=tpm2 "$CRYPT_DISK"
+  else
+    echo
+    echo "Either clear the existing TPM2 keyslot before retrying, else choose 'y' next time."
+    echo "Exiting..."
+    [[ "$0" = "${BASH_SOURCE[0]}" ]] && exit 1 || return 1
+  fi
 fi
 
 ## Run crypt enroll

--- a/build/ublue-os-luks/luks-enable-tpm2-autounlock
+++ b/build/ublue-os-luks/luks-enable-tpm2-autounlock
@@ -68,7 +68,7 @@ fi
 if cryptsetup luksDump "$CRYPT_DISK" | grep systemd-tpm2 > /dev/null; then
   KEYSLOT=$(cryptsetup luksDump "$CRYPT_DISK"|grep -A29 systemd-tpm2|grep Keyslot|awk '{print $2}')
   echo "TPM2 already present in LUKS Keyslot $KEYSLOT of $CRYPT_DISK."
-  echo "Remove the existing TPM2 enrollment with ujust remove-luks-tpm2-autounlock"
+  echo "Remove the existing TPM2 enrollment before trying again."
   echo "Exiting..."
   [[ "$0" = "${BASH_SOURCE[0]}" ]] && exit 1 || return 1
 fi

--- a/build/ublue-os-luks/luks-enable-tpm2-autounlock
+++ b/build/ublue-os-luks/luks-enable-tpm2-autounlock
@@ -49,7 +49,7 @@ else
 fi
 
 SET_PIN_ARG=""
-read -p "Would you like to set a pin? " -n 1 -r
+read -p "Would you like to set a pin? (Y/n)" -n 1 -r
 echo
 if [[ $REPLY =~ ^[Yy]$ ]]; then
   SET_PIN_ARG=" --tpm2-with-pin=yes "

--- a/build/ublue-os-luks/luks-enable-tpm2-autounlock
+++ b/build/ublue-os-luks/luks-enable-tpm2-autounlock
@@ -68,9 +68,8 @@ fi
 if cryptsetup luksDump "$CRYPT_DISK" | grep systemd-tpm2 > /dev/null; then
   KEYSLOT=$(cryptsetup luksDump "$CRYPT_DISK"|grep -A29 systemd-tpm2|grep Keyslot|awk '{print $2}')
   echo "TPM2 already present in LUKS Keyslot $KEYSLOT of $CRYPT_DISK."
-  echo "Remove the existing TPM2 enrollment before trying again."
-  echo "Exiting..."
-  [[ "$0" = "${BASH_SOURCE[0]}" ]] && exit 1 || return 1
+  echo "Wiping systemd-tpm2 from LUKS Keyslot $KEYSLOT of $CRYPT_DISK."
+  systemd-cryptenroll --wipe-slot=$KEYSLOT "$CRYPT_DISK"
 fi
 
 ## Run crypt enroll


### PR DESCRIPTION
luks tpm2 auto lock/unlock scripts should not actually reference ujust since they can be used without it.

if user has found these ujust recipes, it should be obvious what to do from the ujust list of recipes.

Also, why not wipe and re-enroll. 

Closes: #326