### PR TITLE
chore: remove k8s tools brew from config ujust

### DIFF
--- a/build/ublue-os-just/06-k8s-dev-tools.just
+++ b/build/ublue-os-just/06-k8s-dev-tools.just
@@ -1,7 +1,0 @@
-# vim: set ft=make :
-
-# Install Kubernetes CLI dev tools
-k8s-dev-tools:
-    #!/usr/bin/bash
-    echo "Adding Kubernetes command line tools..."
-    brew bundle --file /usr/share/ublue-os/homebrew/kubernetes.Brewfile

--- a/files/usr/ublue-os/homebrew/kubernetes.Brewfile
+++ b/files/usr/ublue-os/homebrew/kubernetes.Brewfile
@@ -1,7 +1,0 @@
-brew "k9s"
-brew "krew"
-brew "kompose"
-brew "kubectl"
-brew "kubectx"
-brew "kustomize"
-brew "helm"


### PR DESCRIPTION
`ujust brew` is not a thing anymore and these k8s tools seem to be more fitting upstream, like on Bluefin-dx or Bazzite-dx or something like that. Would that be reasonable? It just feels so out of place here, these werent even referenced anywhere else so...
