### PR TITLE
chore(fedora-distrobox): Moving fedora-distrobox to ublue-os/toolboxes

### DIFF
--- a/build/ublue-os-just/etc-distrobox/distrobox.ini
+++ b/build/ublue-os-just/etc-distrobox/distrobox.ini
@@ -24,7 +24,7 @@ nvidia=true
 pull=true
 
 [fedora]
-image=ghcr.io/ublue-os/fedora-distrobox:latest
+image=ghcr.io/ublue-os/fedora-toolbox:latest
 nvidia=true
 pull=true
 


### PR DESCRIPTION
This completes the move to one image for fedora toolboxes and distroboxes under the ublue-os/toolboxes repo. See [Issue #1 here](https://github.com/ublue-os/toolboxes/issues/1)
