### PR TITLE
fix(just): incorrect config files in configure-broadcom-wl

### DIFF
--- a/build/ublue-os-just/50-akmods.just
+++ b/build/ublue-os-just/50-akmods.just
@@ -24,7 +24,7 @@ configure-broadcom-wl ACTION="prompt":
       sudo rm -f /etc/modprobe.d/default-disable-broadcom-wl.conf
       echo "${bold}Enabled${normal} Broadcom Wireless, please reboot for changes to take effect"
     elif [ "${OPTION,,}" == "disable" ]; then
-      sudo bash -c '> /etc/modules-load.d/broadcom-wl-blacklist.conf'
-      sudo bash -c 'echo "blacklist wl" > /etc/modules-load.d/default-disable-broadcom-wl.conf'
+      sudo ln -sf /dev/null /etc/modprobe.d/broadcom-wl-blacklist.conf
+      sudo bash -c 'echo "blacklist wl" > /etc/modprobe.d/default-disable-broadcom-wl.conf'
       echo "${bold}Disabled${normal} Broadcom Wireless, please reboot for changes to take effect"
     fi


### PR DESCRIPTION
fix: When disabling the wl driver, the files have to be written in /etc/modprobe.d also use a symlink to /dev/null to override the distribution-provided config.