### PR TITLE
fix(just): separate just and ujust

### DIFF
--- a/build/ublue-os-just/etc-profile.d/ublue-os-just.sh
+++ b/build/ublue-os-just/etc-profile.d/ublue-os-just.sh
@@ -1,19 +1,17 @@
-# Add uBlue's justfiles to users with home directories which lack a justfile.
+# Add a custom justfile to users with home directories which lack a justfile.
 
 if [ ! -z "$HOME" ] && [ -d "$HOME" ] && [ ! -f "${HOME}/.justfile" ]; then
   cat > "${HOME}/.justfile" << EOF
-import "/usr/share/ublue-os/justfile"
+# You can add your own commands here!
+# These commands are separate from the ujust commands.
+# Learn more about just at https://github.com/casey/just
+
+# Choose
+_default:
+  just --choose
+
+# Edit the justfile
+edit: 
+  just -e
 EOF
-fi
-
-if [ -f "${HOME}/.justfile" ]; then
-  if ! grep -Fxq 'import "/usr/share/ublue-os/justfile"' "${HOME}/.justfile"; then
-    # Remove any lines we may have added previously.
-    sed -i '/!include \/usr\/share\/ublue-os\/just\/.*.just/d' "${HOME}/.justfile"
-    sed -i '/!include \/usr\/share\/ublue-os\/justfile/d' "${HOME}/.justfile"
-
-    # Point to the new main justfile, place it as the first line
-    echo '# You can add your own commands here! For documentation, see: https://ublue.it/guide/just/' | tee -a "${HOME}/.justfile"
-    echo 'import "/usr/share/ublue-os/justfile"' | tee -a "${HOME}/.justfile"
-  fi
 fi


### PR DESCRIPTION
Currently the justfile in the home directory is automatically being cluttered with ujust commands. This PR separates both justfiles better, while also providing a simple explanation of how to set up just commands. The original link is dead, so I replaced it with the just GitHub link.

Let me know if we should add or change any commands. `edit` works as a simple example, but maybe we could add `help` too. 

Closes ublue-os/bluefin#2108