### PR TITLE
feat: remove opentabletdriver udev rules

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -8,16 +8,6 @@ ADD https://codeberg.org/fabiscafe/game-devices-udev/archive/main.tar.gz /tmp/ub
 # Add udev rules from repository
 ADD files/etc/udev/rules.d /tmp/ublue-os/udev-rules/etc/udev/rules.d
 
-# Install OpenTabletDriver udev rules from their portable releases
-RUN mkdir -p /tmp/OpenTabletDriver/ && \
-mkdir -p /etc/udev/rules.d/ && \
-curl -s https://api.github.com/repos/OpenTabletDriver/OpenTabletDriver/releases/latest \
-| jq -r '.assets | sort_by(.created_at) | .[] | select (.name|test("opentabletdriver.*tar.gz$")) | .browser_download_url' \
-| wget -qi - -O /tmp/OpenTabletDriver/opentabletdriver.tar.gz && \
-tar --strip-components=1 -xvzf /tmp/OpenTabletDriver/opentabletdriver.tar.gz -C /tmp/OpenTabletDriver && \
-mv /tmp/OpenTabletDriver/etc/udev/rules.d/70-opentabletdriver.rules /tmp/ublue-os/udev-rules/etc/udev/rules.d/71-opentabletdriver-ublue.rules && \
-rm -rf /tmp/OpenTabletDriver
-
 # Install Sunshine udev rules from their github repo
 RUN mkdir -p /tmp/Sunshine/ && \
 mkdir -p /etc/udev/rules.d/ && \


### PR DESCRIPTION
## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.

remove opentabletdriver udev rules because it can cause some issue when user want to use pen tablet settings from desktop environment 