### PR TITLE
Do not clean podman volumes

### DIFF
--- a/build/ublue-os-just/20-clean.just
+++ b/build/ublue-os-just/20-clean.just
@@ -1,9 +1,8 @@
 # vim: set ft=make :
 
-# Clean up old up unused podman images, volumes, flatpak packages and rpm-ostree content
+# Clean up old up unused podman images, flatpak packages and rpm-ostree content
 clean-system:
     #!/usr/bin/bash
     podman image prune -af
-    podman volume prune -f
     flatpak uninstall --unused
     rpm-ostree cleanup -bm


### PR DESCRIPTION
I would recommend against cleaning podman volumes. I did run `ujust clean-system`, and all my volumes were gone.

Luckily this wasn't on a production system, but I think it also cleans up volumes when the container(s) aren't running.

Also sometimes you would like to keep a volume, but remove the container for some reason. 